### PR TITLE
Fixed the link to the Groovy DSL

### DIFF
--- a/documentation/other_formats.md
+++ b/documentation/other_formats.md
@@ -9,5 +9,5 @@ Beyond the built in [XML](xml_format.html), [YAML](yaml_format.html), [JSON](jso
 the Liquibase extension system allows you to create changelog files in whatever format you like.
 
 Additional community-managed formats include:
-- [Groovy Liquibase](https://github.com/tlberglund/groovy-liquibase)
+- [Groovy Liquibase](https://github.com/liquibase/liquibase-groovy-dsl)
 - [Clojure Liquibase Wrapper](https://github.com/kumarshantanu/clj-liquibase)


### PR DESCRIPTION
This pull request will address https://liquibase.jira.com/browse/CORE-2639

I don't know if this should now be considered a Liquibase project because it is housed in the Liquibase organization, or if we still consider this a community maintained DSL since it is maintained separately from the Liquibase core.
