### PR TITLE
Fix broken links "http://ww.liquibase.org" --> "http://www.liquibase.org"

### DIFF
--- a/_posts/2007-06-07-building-database-tests-that-dont-break.md
+++ b/_posts/2007-06-07-building-database-tests-that-dont-break.md
@@ -3,7 +3,7 @@ layout: default
 subnav: subnav_blog.md
 title: Building Database Tests that Don't Break
 ---
-As I discussed in <a href="http://ww.liquibase.org/2007/06/unit-testing-database-access-layer.html">Unit Testing the Database</a>, a difficulty you run into when using a shared dataset for unit tests is making sure you write your test in such a way that changes to the dataset will not break older tests.
+As I discussed in <a href="http://www.liquibase.org/2007/06/unit-testing-database-access-layer.html">Unit Testing the Database</a>, a difficulty you run into when using a shared dataset for unit tests is making sure you write your test in such a way that changes to the dataset will not break older tests.
 
 Note: depending on the database access framework you use, you will actually access the database through a Connection, EntityManager, Session, PersistenceManager etc.  I'll use the term "Connection" generically for any of these access types because the same pattern applies to them all.
 

--- a/_posts/2009-03-24-what-effects-changeset-checksums.md
+++ b/_posts/2009-03-24-what-effects-changeset-checksums.md
@@ -14,4 +14,4 @@ We try to keep as many false-positives and false-negitives out of the process by
 That means that you can reformat your XML (for the most part) as well as add or change preconditions, contexts, and validCheckSum tags without effecting the checksum. The only time that the xml reformat can cause problems is if a text block such as an `<sql>` tag is reformatted.
 
 
-So don't fear the checksum. It is there to help you out and you can add information around already ran changesets without problems. And if you do need to change your original changes, <a href="http://ww.liquibase.org/2008/10/dealing-with-changing-changesets.html">there are ways to deal with the checksum problems</a>.
+So don't fear the checksum. It is there to help you out and you can add information around already ran changesets without problems. And if you do need to change your original changes, <a href="http://www.liquibase.org/2008/10/dealing-with-changing-changesets.html">there are ways to deal with the checksum problems</a>.

--- a/_posts/2009-07-06-liquibase-20-beta-1-released.md
+++ b/_posts/2009-07-06-liquibase-20-beta-1-released.md
@@ -11,4 +11,4 @@ Beta 1 of Liquibase 2.0 has been released. It can be downloaded from <a href="ht
 The main improvement over <a href="http://www.liquibase.org/2009/06/liquibase-20-milestone-1-released.html">milestone 1</a> is that it can be ran against existing changelog scripts, so it can be fully tested with existing databases.
 
 
-Also, do not forget the <a href="http://ww.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Liquibase Extension Contest</a> currently underway!
+Also, do not forget the <a href="http://www.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Liquibase Extension Contest</a> currently underway!

--- a/_posts/2009-08-31-extension-contest-extended.md
+++ b/_posts/2009-08-31-extension-contest-extended.md
@@ -8,4 +8,4 @@ title: Extension contest extended
 Due to us missing milestones on the liquibase 2.0 release, we are pushing the deadline for the plugin contest back to noon Central US time, September 30th. Winners announced October 15th   All other rules are the same.
 
 
-<a href="http://ww.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Full details</a>
+<a href="http://www.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Full details</a>

--- a/_posts/2009-10-08-liquibase-2-0-rc1-released.md
+++ b/_posts/2009-10-08-liquibase-2-0-rc1-released.md
@@ -12,7 +12,7 @@ The primary focus of the 2.0 release is extensibility and building community. In
 
 - Major re-architecting of codebase to expose a flexible, extensible, stable API
 - Replacing the old mailing lists with a <a href="http://www.liquibase.org/forum">message system</a>
-- Extension/plug-in portal and <a href="http://ww.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Extension Contest</a> (closed for judging)
+- Extension/plug-in portal and <a href="http://www.liquibase.org/2009/06/liquibase-extension-contest-2009-now-underway.html">Extension Contest</a> (closed for judging)
 - <a href="http://liquibase.jira.com/browse/CORE">New Feature/Issue tracker</a>
 - <a href="http://liquibase.jira.com/source/browse/CORE">New source repository and browser</a>
 - <a href="http://www.liquibase.org/ci">Publicly available build server</a>

--- a/_posts/2009-10-15-liquibase-2009-plugin-contest-winners.md
+++ b/_posts/2009-10-15-liquibase-2009-plugin-contest-winners.md
@@ -4,7 +4,7 @@ subnav: subnav_blog.md
 title: Liquibase 2009 Plugin Contest Winners
 ---
 
-<img class="alignright size-full wp-image-161" title="sponsors" src="http://ww.liquibase.org/wp-content/uploads/2009/10/sponsors.png" alt="sponsors" width="360" height="233" />Congratulations to the winners of the <a href="http://liquibase.jira.com/wiki/display/CONTRIB/Liquibase+Extension+Contest+2009">2009 Liquibase Plugin Contest</a>!
+<img class="alignright size-full wp-image-161" title="sponsors" src="http://www.liquibase.org/wp-content/uploads/2009/10/sponsors.png" alt="sponsors" width="360" height="233" />Congratulations to the winners of the <a href="http://liquibase.jira.com/wiki/display/CONTRIB/Liquibase+Extension+Contest+2009">2009 Liquibase Plugin Contest</a>!
 
 
 *Grand Prize (Choice of 5 O'Reilly Books, donated by <a href="http://www.oreilly.com">O'Reilly</a>):*<a href="http://liquibase.jira.com/wiki/display/CONTRIB/Oracle+Extensions"> </a>


### PR DESCRIPTION
I found a few broken links in the online documentation.  These are all related to using "ww." in the URL rather than "www."
