### PR TITLE
Fixed description of including changeLog several times

### DIFF
--- a/documentation/include.md
+++ b/documentation/include.md
@@ -40,6 +40,6 @@ The reason to use the `<include>` tag rather than using XML's built-in include f
 
 Currently there is no checking for looping changelogs or double inclusion of changelogs.
 
-If you include a changelog twice, you shouldn't run into problems because the second time around, Liquibase will know that the changeSets have been run and won't run them again (unless there is a runAlways tag). Do not rely on this functionality remaining constant.
+If you include a changelog twice, you shouldn't run into problems because the second time around, Liquibase will know that the changeSets have been run and won't run them again (even if there is a runAlways tag).
 
 If you create a changeLog loop (root.changelog.xml includes news.changelog.xml which includes root.changelog.xml) you will get an infinite loop. Checks for loops is a feature on our list of enhancements, but is currently not implemented


### PR DESCRIPTION
[CORE-1887](https://liquibase.jira.com/browse/CORE-1887)
After changes made in this [commit](https://github.com/liquibase/liquibase/commit/48f76714642d0e1fe21e74c6d463990e937f7149) even if there is a runAlways tag changeSet is ignored.