### PR TITLE
update Groovy Liquibase link

### DIFF
--- a/documentation/other_formats.md
+++ b/documentation/other_formats.md
@@ -9,5 +9,5 @@ Beyond the built in [XML](xml_format.html), [YAML](yaml_format.html), [JSON](jso
 the Liquibase extension system allows you to create changelog files in whatever format you like.
 
 Additional community-managed formats include:
-- [Groovy Liquibase](https://github.com/tlberglund/groovy-liquibase)
+- [Groovy Liquibase](https://github.com/liquibase/groovy-liquibase)
 - [Clojure Liquibase Wrapper](https://github.com/kumarshantanu/clj-liquibase)


### PR DESCRIPTION
Tim Berglund's Groovy Liquibase extension was made a core Liquibase extension. Update the link to point to the current repository.