### PR TITLE
updated all schema references examples to newest v3.6

### DIFF
--- a/bestpractices.md
+++ b/bestpractices.md
@@ -32,7 +32,7 @@ The master.xml includes the changelog for the releases in the correct order. In 
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
   <include file="com/example/db/changelog/db.changelog-1.0.xml"/> 
   <include file="com/example/db/changelog/db.changelog-1.1.xml"/> 
@@ -45,10 +45,10 @@ Each of the included XML files needs to be in the same format as a standard XML 
 {% highlight xml %}
 <?xml version="1.0" encoding="UTF-8"?> 
 <databaseChangeLog 
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9" 
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog" 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd"> 
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"> 
   <changeSet author="authorName" id="changelog-1.0">
     <createTable tableName="TablesAndTables">
       <column name="COLUMN1" type="TEXT">

--- a/dbdoc/changelogs/changelogs/common/common.tests.changelog.xml.xml
+++ b/dbdoc/changelogs/changelogs/common/common.tests.changelog.xml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.4"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.4 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.4.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
     <changeSet id="datatypetest-1" author="nvoxland">
         <createTable tableName="dataTypeTest">

--- a/dbdoc/changelogs/changelogs/common/schema.tests.changelog.xml.xml
+++ b/dbdoc/changelogs/changelogs/common/schema.tests.changelog.xml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.4"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.4 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.4.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
     <changeSet id="1" author="nvoxland">
         <createTable schemaName="liquibaseb" tableName="person2">

--- a/dbdoc/changelogs/changelogs/mysql/complete/included.changelog.xml.xml
+++ b/dbdoc/changelogs/changelogs/mysql/complete/included.changelog.xml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.4"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.3 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.3.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <preConditions>
             <dbms type="mysql"/>
     </preConditions>

--- a/dbdoc/changelogs/changelogs/mysql/complete/oldname.changelog.xml.xml
+++ b/dbdoc/changelogs/changelogs/mysql/complete/oldname.changelog.xml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.3"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.3 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.3.xsd"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
         
         logicalFilePath="changelogs/mysql/complete/oldname.changelog.xml">
     <preConditions>

--- a/dbdoc/changelogs/changelogs/mysql/complete/root.changelog.xml.xml
+++ b/dbdoc/changelogs/changelogs/mysql/complete/root.changelog.xml.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.3"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.3 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.3.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <preConditions>
         <dbms type="mysql"/>
         <sqlCheck expectedResult="1">select 1</sqlCheck>

--- a/documentation/changelog_parameters.md
+++ b/documentation/changelog_parameters.md
@@ -32,7 +32,7 @@ Parameter values are looked up in the following order:
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <property name="clob.type" value="clob" dbms="oracle"/>

--- a/documentation/changeset.md
+++ b/documentation/changeset.md
@@ -11,10 +11,10 @@ The changeSet tag is what you use to group database changes/<a href="changes/ind
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.7"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.7
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.7.xsd">
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet id="1" author="bob">
         <comment>A sample change log</comment>
         <createTable/>

--- a/documentation/databasechangelog.md
+++ b/documentation/databasechangelog.md
@@ -30,7 +30,7 @@ If all preconditions are met, Liquibase will then begin running [changeSet](chan
 
 The XML schema for the databaseChangeLog tag is available at:
 
-* [http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd](http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd) **Since 3.1**
+* [http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd](http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd) **Since 3.6**
 
 Some legacy XSDs are listed on [the XML Format page](xml_format.html).
 
@@ -52,7 +52,7 @@ Each changeSet contains an "id" tag and an "author" tag. These tags, along with 
     xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 </databaseChangeLog>
 {% endhighlight %}

--- a/documentation/diff.md
+++ b/documentation/diff.md
@@ -112,10 +112,10 @@ In change log mode, the an XML change log of what is necessary to upgrade the ba
 {% highlight xml %}
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.1"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.1
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.1.xsd">
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet author="diff-generated" id="1185206820975-1">
         <addColumn tableName="CREDIT">
             <column name="MONTH" type="VARCHAR2(10)"/>

--- a/documentation/generating_changelogs.md
+++ b/documentation/generating_changelogs.md
@@ -27,10 +27,10 @@ liquibase --driver=oracle.jdbc.OracleDriver \
 {% highlight xml %}
 <?xml version="1.0" encoding="UTF-8"?>
 <databaseChangeLog
-    xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.1"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.1
-    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.1.xsd">
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet author="diff-generated" id="1185214997195-1">
         <createTable name="BONUS">
             <column name="ENAME" type="VARCHAR2(10,0)"/>

--- a/documentation/include.md
+++ b/documentation/include.md
@@ -10,10 +10,10 @@ The include tag allows you to break up your change-logs into more manageable pie
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <include file="com/example/news/news.changelog.xml"/>
     <include file="com/example/directory/directory.changelog.xml"/>
 </databaseChangeLog>

--- a/documentation/includeall.md
+++ b/documentation/includeall.md
@@ -10,10 +10,10 @@ The includeAll tag allows you to break up your change-logs into more manageable 
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <includeAll path="com/example/changelogs/"/>
 </databaseChangeLog>
 {% endhighlight %}

--- a/documentation/preconditions.md
+++ b/documentation/preconditions.md
@@ -22,10 +22,10 @@ Preconditions at the changelog level apply to **all** changesets, not just those
 <?xml version="1.0" encoding="UTF-8"?>
 
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.8"
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.8
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.8.xsd">
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <preConditions>
         <dbms type="oracle" />
         <runningAs username="SYSTEM" />

--- a/documentation/trimming_changelogs.md
+++ b/documentation/trimming_changelogs.md
@@ -15,10 +15,10 @@ If it is worth the risk, why is it work the risk? Sometimes the problem is that 
 
 {% highlight xml %}
 <databaseChangeLog
-            xmlns="http://www.liquibase.org/xml/ns/dbchangelog/3.3"
+            xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/3.3
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+            xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <include file="com/example/news/news.changelog.xml"/>
     <include file="com/example/directory/directory.changelog.xml"/>
 </databaseChangeLog>
@@ -42,7 +42,7 @@ Suppose instead you have a "cart" table that is created in one changeSet, then a
 
 {% highlight xml %}
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                       xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+                       xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet author="nvoxland" id="1">
         <createTable tableName="cart">
             <column name="id" type="int"/>
@@ -68,7 +68,7 @@ One option would be to combine everything into a new changeSet using the existin
 
 {% highlight xml %}
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet author="nvoxland" id="1">
         <validCheckSum>7:f24b25ba0fea451728ffbade634f791d</validCheckSum>
         <createTable tableName="cart">
@@ -86,7 +86,7 @@ If you have some databases where the promo_code and/or abandoned columns have no
 
 {% highlight xml %}
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <changeSet author="nvoxland" id="1">
         <validCheckSum>7:f24b25ba0fea451728ffbade634f791d</validCheckSum>
         <createTable tableName="cart">

--- a/documentation/xml_format.md
+++ b/documentation/xml_format.md
@@ -11,6 +11,11 @@ Liquibase supports XML as a format for storing your changelog files.
 
 XSD schema definitions are available for each Liquibase version. Since there are no changelog format changes in patch versions, there are only xsd files that correspond to major.minor versions.
 
+* http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+* http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+* http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd
+* http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd
+* http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd
 * http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
 * http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
 * http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
@@ -35,7 +40,7 @@ None
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <preConditions>

--- a/index.md
+++ b/index.md
@@ -94,7 +94,7 @@ includeDaticalBox: true
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <preConditions>

--- a/quickstart.md
+++ b/quickstart.md
@@ -14,7 +14,7 @@ The [database changelog file](documentation/databasechangelog.html) is where all
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
 </databaseChangeLog>
 {% endhighlight %}
@@ -32,7 +32,7 @@ Think of each change set as an atomic change that you want to apply to your data
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
 
     <changeSet id="1" author="bob">
         <createTable tableName="department">

--- a/tutorial-using-oracle.md
+++ b/tutorial-using-oracle.md
@@ -141,7 +141,7 @@ Choose Tools &gt; Preferences &gt; <acronym title="Extensible Markup Language">X
 </p>
 <div ><table >
 	<tr >
-		<th >Schema:</th><td > http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd </td>
+		<th >Schema:</th><td > http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd </td>
 	</tr>
 	<tr >
 		<th >Extension: </th><td >xml</td>
@@ -416,9 +416,9 @@ JDeveloper is a great tool for editing <acronym title="Extensible Markup Languag
 <strong>trunk/update.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;include file=&quot;v000/master.xml&quot; /&gt;
 &lt;/databaseChangeLog&gt;
 </pre>
@@ -431,9 +431,9 @@ Create the file that will later contain the includes of each changeLog in order 
 <strong>trunk/v000/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 0 --&gt;
         &lt;sqlCheck expectedResult=&quot;0&quot;&gt;
@@ -511,9 +511,9 @@ Create the following files:
 <strong>trunk/v000/2009-10-15-73.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;createTable tableName=&quot;departments&quot;
                      remarks=&quot;The departments of this company. Does not include geographical divisions.&quot;&gt;
@@ -559,9 +559,9 @@ Note that the table and column remarks will be applied as table and column comme
 <strong>trunk/latest/trg/departments_bi.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot; runOnChange=&quot;true&quot;&gt;
         &lt;createProcedure&gt;
 create trigger departments_bi before insert on departments
@@ -589,9 +589,9 @@ Update the master.xml to include the change:
 <strong>trunk/v000/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 0 --&gt;
         &lt;sqlCheck expectedResult=&quot;0&quot;&gt;
@@ -653,9 +653,9 @@ Both objects are of the "replaceable" type, i.e. a new version can simply replac
 <strong>trunk/v000/master.xml</strong> (add the new change to the end of the file)
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 0 --&gt;
         &lt;sqlCheck expectedResult=&quot;0&quot;&gt;
@@ -672,9 +672,9 @@ Both objects are of the "replaceable" type, i.e. a new version can simply replac
 <strong>trunk/v000/2009-10-15-59.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;include file=&quot;latest/pks/departments_pck.xml&quot;/&gt;
     &lt;include file=&quot;latest/pkb/departments_pck.xml&quot;/&gt;
     &lt;include file=&quot;latest/vw/departments_vw.xml&quot;/&gt;
@@ -684,9 +684,9 @@ Both objects are of the "replaceable" type, i.e. a new version can simply replac
 <strong>trunk/latest/pks/departments_pck.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot; runOnChange=&quot;true&quot;&gt;
         &lt;createProcedure&gt;
 create or replace package departments_pck as
@@ -703,9 +703,9 @@ end departments_pck;
 <strong>trunk/latest/pkb/departments_pck.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot; runOnChange=&quot;true&quot;&gt;
         &lt;createProcedure&gt;
 create or replace package body departments_pck as
@@ -725,9 +725,9 @@ end departments_pck;
 <strong>trunk/latest/vw/departments_vw.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot; runOnChange=&quot;true&quot;&gt;
         &lt;createView viewName=&quot;departments_vw&quot;&gt;
             select id, dname
@@ -780,9 +780,9 @@ The last change to version 0 has been made. After all these changes have been ap
 <strong>trunk/v000/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!--These changes should only be run against a schema with major version 0--&gt;
         &lt;sqlCheck expectedResult=&quot;0&quot;&gt;
@@ -841,9 +841,9 @@ Our (manual) utility will create these files:
 <strong>trunk/install/tab/departments.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;createTable tableName=&quot;departments&quot;
                      remarks=&quot;The departments of this company. Does not include geographical divisions.&quot;&gt;
@@ -863,9 +863,9 @@ Our (manual) utility will create these files:
 <strong>trunk/install/tab/employees.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;createTable tableName=&quot;employees&quot;&gt;
             &lt;column name=&quot;id&quot; type=&quot;number(4,0)&quot;&gt;
@@ -885,9 +885,9 @@ Our (manual) utility will create these files:
 <strong>trunk/install/seq/departments_seq.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;createSequence sequenceName=&quot;departments_seq&quot;/&gt;
     &lt;/changeSet&gt;
@@ -897,9 +897,9 @@ Our (manual) utility will create these files:
 <strong>trunk/install/cst/employees.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;addForeignKeyConstraint baseColumnNames=&quot;dpt_id&quot;
                                  baseTableName=&quot;employees&quot;
@@ -927,9 +927,9 @@ Create a new master.xml in this directory:
 <strong>trunk/v001/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 1 --&gt;
         &lt;sqlCheck expectedResult=&quot;1&quot;&gt;
@@ -948,9 +948,9 @@ Edit the update file:
 <strong>trunk/update.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;include file=&quot;v001/master.xml&quot; /&gt;
 &lt;/databaseChangeLog&gt;</pre>
 
@@ -977,9 +977,9 @@ Create the <code>install.xml</code>. This file does the fresh install of objects
 <strong> trunk/install.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;includeAll path=&quot;install/tab/&quot; /&gt;
     &lt;includeAll path=&quot;install/seq&quot; /&gt;
     &lt;includeAll path=&quot;install/cst&quot; /&gt;
@@ -1177,9 +1177,9 @@ Remember that our changes are now taking us from version 1.x, so the changelogs 
 <strong> trunk/v001/2009-10-16-102.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;addColumn tableName=&quot;employees&quot;&gt;
             &lt;column name=&quot;fixed_salary&quot; type=&quot;number(6,2)&quot;
@@ -1205,9 +1205,9 @@ Update <code>master.xml</code> to include this file:
 <strong>trunk/v001/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 1 --&gt;
         &lt;sqlCheck expectedResult=&quot;1&quot;&gt;
@@ -1409,9 +1409,9 @@ Create the changelog:
 <strong>trunk/v001/2009-10-16-105.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;addColumn tableName=&quot;departments&quot;&gt;
             &lt;column name=&quot;mgr_id&quot; type=&quot;number(4,0)&quot;/&gt;
@@ -1437,9 +1437,9 @@ Update <code>master.xml</code> to include this file:
 <strong>trunk/v001/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 1 --&gt;
         &lt;sqlCheck expectedResult=&quot;1&quot;&gt;
@@ -1505,9 +1505,9 @@ call Liquibase --changeLogFile=update.xml update</pre>
 <strong>trunk/upgrade_to_major.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;include file=&quot;v001/master.xml&quot; /&gt;
 &lt;/databaseChangeLog&gt;</pre>
 
@@ -1528,9 +1528,9 @@ Create the changelog:
 <strong>trunk/v002/2009-10-18-114.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;changeSet author=&quot;jsmith&quot; id=&quot;1&quot;&gt;
         &lt;renameColumn newColumnName=&quot;full_name&quot; oldColumnName=&quot;ename&quot; tableName=&quot;employees&quot;/&gt;
     &lt;/changeSet&gt;
@@ -1544,9 +1544,9 @@ Update <code>master.xml</code> to include this file:
 <strong>trunk/v002/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 2 --&gt;
         &lt;sqlCheck expectedResult=&quot;2&quot;&gt;
@@ -1592,9 +1592,9 @@ Change 114 will be referenced in <code>v001/master.xml</code> as follows:
 <strong>branch_1.x/v001/master.xml</strong>
 </p>
 <pre >&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;
-&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9&quot;
+&lt;databaseChangeLog xmlns=&quot;http://www.liquibase.org/xml/ns/dbchangelog&quot;
                    xmlns:xsi=&quot;http://www.w3.org/2001/XMLSchema-instance&quot;
-                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog/1.9 http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd&quot;&gt;
+                   xsi:schemaLocation=&quot;http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd&quot;&gt;
     &lt;preConditions&gt;
         &lt;!-- These changes should only be run against a schema with major version 1 --&gt;
         &lt;sqlCheck expectedResult=&quot;1&quot;&gt;


### PR DESCRIPTION
I've updated all examples where old schema was used, to newest v3.6 XSD
also droped version suffix from changelogdb:
`http://www.liquibase.org/xml/ns/dbchangelog/1.6`
becomes
`http://www.liquibase.org/xml/ns/dbchangelog`

the only exclusions where blog posts and migration guides