### PR TITLE
Replace "Datical DB" with "Datical"

### DIFF
--- a/bestpractices.md
+++ b/bestpractices.md
@@ -94,7 +94,7 @@ Leverage Liquibase to manage your Reference Data. Environment separation (DEV, Q
 * Test the new application code together with the database change;
 * Commit both the changeSet and the application code.
 
-## Consider Datical DB ##
+## Consider Datical ##
 
 Datical is a commercial product with builds on the core Liquibase functionality. Beyond versioning and managing database changes, Datical bridges the gap between development and operations with capabilities that enable a fully unified and automated path for database code. 
 
@@ -106,6 +106,6 @@ Datical is a commercial product with builds on the core Liquibase functionality.
 * Datical integrates with ticketing systems such as JIRA to make it easy to trace database changes back to source code and initial requirements. This same capability also makes it easy to hold or accelerate feature sets.
 * Datical can snapshot and compare database schemas to help identify and address drift
 
-For more information on Datical DB, visit <a href="http://www.datical.com/liquibase/" target="_blank" onClick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false">http://www.datical.com/Liquibase</a>
+For more information on Datical, visit <a href="http://www.datical.com/liquibase/" target="_blank" onClick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false">http://www.datical.com/Liquibase</a>
 
 


### PR DESCRIPTION
Datical DB is an outdated product name. Marketing now simply uses "Datical" to refer to the product.