### PR TITLE
Add clarification regarding test data changesets.

### DIFF
--- a/documentation/contexts.md
+++ b/documentation/contexts.md
@@ -53,7 +53,7 @@ __Availability:__
 
 ## Using Contexts for Test Data ##
 
-If you are managing your test data with Liquibase, the best way to include it is in-line with all your other changeSets, but marked with a "test" context. That way, when you want your test data inserted you can run the migrator with the "test" context. When it comes time to migrate your production database, don't include the "test" context, and your test data not be included. If you have multiple test environments or test data sets, simply tag them with different contexts such as "min-test", "integration-test", etc.
+If you are managing your test data with Liquibase, the best way to include it is in-line with all your other changeSets, but marked with a "test" context. That way, when you want your test data inserted you can run the migrator with the "test" context. When it comes time to migrate your production database, don't include the "test" context, and your test data will not be included (bare in mind that if you do not specify any context at all, every changeset will be applied, including those marked with a "test" context). If you have multiple test environments or test data sets, simply tag them with different contexts such as "min-test", "integration-test", etc.
 
 Using contexts to control test data is better than having a separate changeLog tree because later refactorings and changes will be applied to existing test data the same as they are applied to production data. If you had a set of test data that was created and simply added after the database is set up, you would be constantly manually updating your test data scripts to keep them in line with the current database schema.
 


### PR DESCRIPTION
As a new user i found the test data section a little bit confusing as it led me to believe that simply by not specifying a `"test"` context then changesets marked with `"test"` context would not be run. As i understand, this is only true if another context is being specified, but when no context is specified all changesets are applied, including those marked with `"test"` context. I have added a clarification about this.