### PR TITLE
Add documentation for descending attribute on column (for createIndex)

### DIFF
--- a/documentation/changes/create_index.md
+++ b/documentation/changes/create_index.md
@@ -50,7 +50,7 @@ Creates an index on an existing column or set of columns.
             tableName="person"
             tablespace="A String"
             unique="true">
-        <column name="address" type="varchar(255)"/>
+        <column name="address" type="varchar(255)" descending="false"/>
     </createIndex>
 </changeSet>
 {% endhighlight %}
@@ -67,6 +67,7 @@ changeSet:
       - column:
           name: address
           type: varchar(255)
+          descending: false
       indexName: idx_address
       schemaName: public
       tableName: person
@@ -89,7 +90,8 @@ changeSet:
             {
               "column": {
                 "name": "address",
-                "type": "varchar(255)"
+                "type": "varchar(255)",
+                "descending": false
               }
             }]
           ,

--- a/documentation/column.md
+++ b/documentation/column.md
@@ -101,6 +101,10 @@ The "column" tag is a tag that is re-used throughout the Liquibase XML when colu
       <td>position</td>
       <td>If used in an 'addColumn' command, this attribute allows you to control where in the table column order the new column goes. Only one of beforeColumn, afterColumn or position are allowed. Expects a one based index <i>Since 3.1</i></td>
     </tr>
+    <tr>
+      <td>descending</td>
+      <td>If used in a 'createIndex' command, this boolean attribute allows you to stipulate that a column should be used in descending order in the index. Defaults to <code>false</code> (i.e. ascending order) <i>Since 3.4</i></td>
+    </tr>
 
   </tbody>
 </table>

--- a/documentation/column.md
+++ b/documentation/column.md
@@ -103,7 +103,7 @@ The "column" tag is a tag that is re-used throughout the Liquibase XML when colu
     </tr>
     <tr>
       <td>descending</td>
-      <td>If used in a 'createIndex' command, this boolean attribute allows you to stipulate that a column should be used in descending order in the index. Defaults to <code>false</code> (i.e. ascending order) <i>Since 3.4</i></td>
+      <td>If used in a 'createIndex' command, this boolean attribute allows you to specify that a column should be used in descending order in the index. Defaults to <code>false</code> (i.e. ascending order) <i>Since 3.4</i></td>
     </tr>
 
   </tbody>


### PR DESCRIPTION
This functionality was added in 3.4.0 via https://liquibase.jira.com/browse/CORE-419 but isn't currently mentioned in the documentation.