### PR TITLE
Update command_line.md

### DIFF
--- a/documentation/command_line.md
+++ b/documentation/command_line.md
@@ -133,6 +133,7 @@ If you run the command line migrator without any arguments, you will get a help 
 <table>
 <tr><th>Option</th><th>Description</th></tr>
 <tr><td>--referenceDriver=&lt;jdbc.driver.ClassName&gt;</td><td>Base Database driver class name.</td></tr>
+<tr><td>--referenceDefaultSchemaName=&lt;schema&gt;</td><td>Base Database default schema name.</td></tr>
 </table>
 
 


### PR DESCRIPTION
Sometimes in a diff, the base and target schemas are differently named, so the schema names need to be identified in both the base and the target. The target schema is identified by the standard parameter while the base schema is identified by "referenceDefaultSchemaName"