### PR TITLE
Changed the location of the Groovy DSL to the right one

### DIFF
--- a/documentation/other_formats.md
+++ b/documentation/other_formats.md
@@ -9,5 +9,5 @@ Beyond the built in [XML](xml_format.html), [YAML](yaml_format.html), [JSON](jso
 the Liquibase extension system allows you to create changelog files in whatever format you like.
 
 Additional community-managed formats include:
-- [Groovy Liquibase](https://github.com/tlberglund/groovy-liquibase)
+- [Groovy Liquibase](https://github.com/liquibase/liquibase-groovy-dsl)
 - [Clojure Liquibase Wrapper](https://github.com/kumarshantanu/clj-liquibase)


### PR DESCRIPTION
The Groovy DSL hasn't been maintained by tlberglund for quite some time, but I've only just gotten around to fixing the link.

This must be a new record for procrastination :-)

At some point I should probably create a page for the Gradle plugin as well...