### PR TITLE
changeset <sql>: fix documentation about usage of <comment> tag

### DIFF
--- a/documentation/changes/sql.md
+++ b/documentation/changes/sql.md
@@ -51,9 +51,11 @@ Note: By default it will attempt to split statements on a ';' or 'go' at the end
     <sql dbms="h2, oracle"
             endDelimiter="\nGO"
             splitStatements="true"
-            stripComments="true">insert into person (name) values ('Bob')
-        <comment>What about Bob?</comment>
+            stripComments="true"
+    >
+        insert into person (name) values ('Bob')
     </sql>
+    <comment>What about Bob?</comment>
 </changeSet>
 {% endhighlight %}
 </div>


### PR DESCRIPTION
&lt;comment> must be a sibling of &lt;sql>, not a child of it

even if XSD says it could ?
http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd

using Liquibase 3.5.4