### PR TITLE
Replacing dead link to abandoned drivers

### DIFF
--- a/sqlite.md
+++ b/sqlite.md
@@ -8,7 +8,7 @@ title: Sqlite
 SQLite is a single-file database which follows the zero-configuration approach.
 It is furthermore easy to use and is thus perfect for your first experiments with liquibase.
 
-There is a jdbc driver available here: [http://www.zentus.com/sqlitejdbc/](http://www.zentus.com/sqlitejdbc/)
+There is a jdbc driver available here: [https://bitbucket.org/xerial/sqlite-jdbc/downloads/](https://bitbucket.org/xerial/sqlite-jdbc/downloads/)
 
 To use sqlite with liquibase you will need the following information:
 


### PR DESCRIPTION
The Xerial driver is an actively maintained fork of the old Zentus drivers.

https://github.com/xerial/sqlite-jdbc