### PR TITLE
Added specifics on connections to mirror existing ones

### DIFF
--- a/databases.md
+++ b/databases.md
@@ -12,10 +12,10 @@ Please find further information about which JDBC driver, URL, classes etc. these
 <table>
 <tr><th>Database</th><th>Type Name</th><th>Notes</th></tr>
 <tr><td><a href="mysql.html">MySQL</a></td><td>mysql</td><td>No Issues</td></tr>
-<tr><td><a href="mariadb.html"MariaDB</a></td><td>mysql</td><td>MariaDB is 100% compatible with MySQL per <a href="https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/">MariaDB developers</a></td></tr>
+<tr><td><a href="mariadb.html">MariaDB</a></td><td>mysql</td><td>MariaDB is 100% compatible with MySQL per <a href="https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/">MariaDB developers</a></td></tr>
 <tr><td><a href="postgresql.html">PostgreSQL</a></td><td>postgresql</td><td>8.2+ is required to use the "drop all database objects" functionality.</td></tr>
-<tr><td>Oracle</td><td>oracle</td><td>11g driver is required when using the diff tool on databases running with AL32UTF8 or AL16UTF16</td></tr>
-<tr><td>Sql Server</td><td>mssql</td><td>No Issues</td></tr>
+<tr><td><a href="oracle.html">Oracle</a></td><td>oracle</td><td>11g driver is required when using the diff tool on databases running with AL32UTF8 or AL16UTF16</td></tr>
+<tr><td><a href="mssql.html">SQL Server</a></td><td>mssql</td><td>No Issues</td></tr>
 <tr><td>Sybase_Enterprise</td><td>sybase</td><td>ASE 12.0+ required. "select into" database option needs to be set. Best driver is JTDS. Sybase does not support transactions for DDL so rollbacks will not work on failures. Foreign keys can not be dropped which can break the rollback or dropAll functionality.</td></tr>
 <tr><td>Sybase_Anywhere</td><td>asany</td><td><b>Since 1.9</b></td></tr>
 <tr><td>DB2</td><td>db2</td><td>No Issues. Will auto-call REORG when necessary.</td></tr>

--- a/databases.md
+++ b/databases.md
@@ -11,9 +11,9 @@ Please find further information about which JDBC driver, URL, classes etc. these
 
 <table>
 <tr><th>Database</th><th>Type Name</th><th>Notes</th></tr>
-  <tr><td><a href="mysql.html">MySQL</a></td><td>mysql</td><td>No Issues</td></tr>
-<tr><td>MariaDB</td><td>mysql</td><td>MariaDB is 100% compatible with MySQL per <a href="https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/">MariaDB developers</a></td></tr>
-<tr><td>PostgreSQL</td><td>postgresql</td><td>8.2+ is required to use the "drop all database objects" functionality.</td></tr>
+<tr><td><a href="mysql.html">MySQL</a></td><td>mysql</td><td>No Issues</td></tr>
+<tr><td><a href="mariadb.html"MariaDB</a></td><td>mysql</td><td>MariaDB is 100% compatible with MySQL per <a href="https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/">MariaDB developers</a></td></tr>
+<tr><td><a href="postgresql.html">PostgreSQL</a></td><td>postgresql</td><td>8.2+ is required to use the "drop all database objects" functionality.</td></tr>
 <tr><td>Oracle</td><td>oracle</td><td>11g driver is required when using the diff tool on databases running with AL32UTF8 or AL16UTF16</td></tr>
 <tr><td>Sql Server</td><td>mssql</td><td>No Issues</td></tr>
 <tr><td>Sybase_Enterprise</td><td>sybase</td><td>ASE 12.0+ required. "select into" database option needs to be set. Best driver is JTDS. Sybase does not support transactions for DDL so rollbacks will not work on failures. Foreign keys can not be dropped which can break the rollback or dropAll functionality.</td></tr>

--- a/databases.md
+++ b/databases.md
@@ -11,7 +11,8 @@ Please find further information about which JDBC driver, URL, classes etc. these
 
 <table>
 <tr><th>Database</th><th>Type Name</th><th>Notes</th></tr>
-<tr><td>MySQL</td><td>mysql</td><td>No Issues</td></tr>
+  <tr><td><a href="mysql.html">MySQL</a></td><td>mysql</td><td>No Issues</td></tr>
+<tr><td>MariaDB</td><td>mysql</td><td>MariaDB is 100% compatible with MySQL per <a href="https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/">MariaDB developers</a></td></tr>
 <tr><td>PostgreSQL</td><td>postgresql</td><td>8.2+ is required to use the "drop all database objects" functionality.</td></tr>
 <tr><td>Oracle</td><td>oracle</td><td>11g driver is required when using the diff tool on databases running with AL32UTF8 or AL16UTF16</td></tr>
 <tr><td>Sql Server</td><td>mssql</td><td>No Issues</td></tr>

--- a/mariadb.md
+++ b/mariadb.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: MariaDB
+---
+
+Running liquibase with the the JDBC driver located in the same directory as liquibase:
+
+{% highlight sh %}
+./liquibase
+  --driver=org.mariadb.jdbc.Driver
+  --classpath=./mariadb-java-client-1.4.6.jar
+  --url="jdbc:mariadb://<IP OR HOSTNAME>:<PORT>/<SCHEMA NAME>" 
+  --changeLogFile=db.changelog-1.0.xml 
+  --username=<MARIADB USERNAME>
+  --password=<MARIADB PASSWORD>
+  generateChangeLog
+{% endhighlight %}

--- a/mysql.md
+++ b/mysql.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: MySQL
+---
+
+Running liquibase with the the JDBC driver located in the same directory as liquibase:
+
+{% highlight sh %}
+./liquibase
+  --driver=com.mysql.jdbc.Driver 
+  --classpath=./mysql-connector-java-5.1.21-bin.jar 
+  --url="jdbc:mysql://<IP OR HOSTNAME>:<PORT>/<SCHEMA NAME>?autoReconnect=true&amp;useSSL=false" 
+  --changeLogFile=db.changelog-1.0.xml 
+  --username=<MYSQL USERNAME>
+  --password=<MYSQL PASSWORD>
+  generateChangeLog
+{% endhighlight %}

--- a/oracle.md
+++ b/oracle.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Oracle
+---
+
+Running liquibase with the the JDBC driver located in the same directory as liquibase:
+
+{% highlight sh %}
+./liquibase
+  --driver=oracle.jdbc.OracleDriver
+  --classpath=./ojdbc14.jar
+  --url="jdbc:oracle:thin:@<IP OR HOSTNAME>:<PORT>:<SERVICE NAME OR SID>""
+  --changeLogFile=db.changelog-1.0.xml 
+  --username=<USERNAME>
+  --password=<PASSWORD>
+  generateChangeLog
+{% endhighlight %}

--- a/postgresql.html
+++ b/postgresql.html
@@ -1,0 +1,17 @@
+---
+layout: default
+title: PostgreSQL
+---
+
+Running liquibase with the the JDBC driver located in the same directory as liquibase:
+
+{% highlight sh %}
+./liquibase
+  --driver=org.postgresql.Driver
+  --classpath=./postgresql-9.2-1002-jdbc4.jar
+  --url="jdbc:postgresql://<IP OR HOSTNAME>:<PORT>/<DATABASE>" 
+  --changeLogFile=db.changelog-1.0.xml 
+  --username=<POSTGRESQL USERNAME>
+  --password=<POSTGRESQL PASSWORD>
+  generateChangeLog
+{% endhighlight %}


### PR DESCRIPTION
We only had Apache_Derby, Informix, and SQLite with details. Fixed this for MySQL, MariaDB (which I added as supported), PostgreSQL, Oracle, and SQL Server (fixed the capitalization on that, too).