### PR TITLE
GitHub-112: Regenerated changes markdown files for liquibase-core 3.8.0.

### DIFF
--- a/_includes/subnav_documentation_changes.md
+++ b/_includes/subnav_documentation_changes.md
@@ -62,9 +62,13 @@
 <li><a href='load_update_data.html'><span>load Update Data</span></a></li>
 <li><a href='merge_columns.html'><span>merge Columns</span></a></li>
 <li><a href='modify_data_type.html'><span>modify Data Type</span></a></li>
+<li><a href='output.html'><span>output</span></a></li>
 <li><a href='rename_column.html'><span>rename Column</span></a></li>
+<li><a href='rename_sequence.html'><span>rename Sequence</span></a></li>
 <li><a href='rename_table.html'><span>rename Table</span></a></li>
 <li><a href='rename_view.html'><span>rename View</span></a></li>
+<li><a href='set_column_remarks.html'><span>set Column Remarks</span></a></li>
+<li><a href='set_table_remarks.html'><span>set Table Remarks</span></a></li>
 <li><a href='sql.html'><span>sql</span></a></li>
 <li><a href='sql_file.html'><span>sql File</span></a></li>
 <li><a href='stop.html'><span>stop</span></a></li>

--- a/documentation/changes/add_auto_increment.md
+++ b/documentation/changes/add_auto_increment.md
@@ -22,8 +22,10 @@ Converts an existing column to be an auto-increment (a.k.a 'identity') column
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Current data type of the column to make auto-increment</td><td style='vertical-align: top'>informix, sybase, unsupported, asany, hsqldb, h2, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Current data type of the column to make auto-increment</td><td style='vertical-align: top'>informix, mariadb, sybase, unsupported, hsqldb, ingres, asany, h2, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>defaultOnNull</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.6</td></tr>
+<tr><td style='vertical-align: top'>generationType</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.6</td></tr>
 <tr><td style='vertical-align: top'>incrementBy</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>startWith</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
@@ -38,10 +40,14 @@ Converts an existing column to be an auto-increment (a.k.a 'identity') column
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addAutoIncrement-example">
+<changeSet author="liquibase-docs"
+        id="addAutoIncrement-example"
+        objectQuotingStrategy="LEGACY">
     <addAutoIncrement catalogName="cat"
             columnDataType="int"
             columnName="id"
+            defaultOnNull="false"
+            generationType="ALWAYS"
             incrementBy="1"
             schemaName="public"
             startWith="100"
@@ -54,11 +60,14 @@ Converts an existing column to be an auto-increment (a.k.a 'identity') column
 changeSet:
   id: addAutoIncrement-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addAutoIncrement:
       catalogName: cat
       columnDataType: int
       columnName: id
+      defaultOnNull: false
+      generationType: ALWAYS
       incrementBy: 1
       schemaName: public
       startWith: 100
@@ -72,12 +81,15 @@ changeSet:
   "changeSet": {
     "id": "addAutoIncrement-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addAutoIncrement": {
           "catalogName": "cat",
           "columnDataType": "int",
           "columnName": "id",
+          "defaultOnNull": false,
+          "generationType": "ALWAYS",
           "incrementBy": 1,
           "schemaName": "public",
           "startWith": 100,
@@ -108,11 +120,14 @@ ALTER TABLE cat.person AUTO_INCREMENT=100;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/add_column.md
+++ b/documentation/changes/add_column.md
@@ -40,7 +40,9 @@ Adds a new column to an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addColumn-example">
+<changeSet author="liquibase-docs"
+        id="addColumn-example"
+        objectQuotingStrategy="LEGACY">
     <addColumn catalogName="cat"
             schemaName="public"
             tableName="person">
@@ -54,6 +56,7 @@ Adds a new column to an existing table
 changeSet:
   id: addColumn-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addColumn:
       catalogName: cat
@@ -72,6 +75,7 @@ changeSet:
   "changeSet": {
     "id": "addColumn-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addColumn": {
@@ -110,11 +114,14 @@ ALTER TABLE cat.person ADD address VARCHAR(255) NULL;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_default_value.md
+++ b/documentation/changes/add_default_value.md
@@ -28,6 +28,7 @@ One of defaultValue, defaultValueNumeric, defaultValueBoolean or defaultValueDat
 <tr><td style='vertical-align: top'>defaultValue</td><td style='vertical-align: top'>Default value. Either this property or one of the other defaultValue* properties are required.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultValueBoolean</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultValueComputed</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>defaultValueConstraintName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultValueDate</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultValueNumeric</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultValueSequenceNext</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
@@ -43,15 +44,18 @@ One of defaultValue, defaultValueNumeric, defaultValueBoolean or defaultValueDat
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addDefaultValue-example">
+<changeSet author="liquibase-docs"
+        id="addDefaultValue-example"
+        objectQuotingStrategy="LEGACY">
     <addDefaultValue catalogName="cat"
-            columnDataType="int"
+            columnDataType="varchar(50)"
             columnName="fileName"
             defaultValue="Something Else"
             defaultValueBoolean="true"
             defaultValueComputed="now"
-            defaultValueDate="A String"
-            defaultValueNumeric="A String"
+            defaultValueConstraintName="A String"
+            defaultValueDate="2008-02-12T12:34:03"
+            defaultValueNumeric="439.2"
             defaultValueSequenceNext="seq_name"
             schemaName="public"
             tableName="file"/>
@@ -63,16 +67,18 @@ One of defaultValue, defaultValueNumeric, defaultValueBoolean or defaultValueDat
 changeSet:
   id: addDefaultValue-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addDefaultValue:
       catalogName: cat
-      columnDataType: int
+      columnDataType: varchar(50)
       columnName: fileName
       defaultValue: Something Else
       defaultValueBoolean: true
       defaultValueComputed: now
-      defaultValueDate: A String
-      defaultValueNumeric: A String
+      defaultValueConstraintName: A String
+      defaultValueDate: 2008-02-12T12:34:03
+      defaultValueNumeric: '439.2'
       defaultValueSequenceNext: seq_name
       schemaName: public
       tableName: file
@@ -85,17 +91,19 @@ changeSet:
   "changeSet": {
     "id": "addDefaultValue-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addDefaultValue": {
           "catalogName": "cat",
-          "columnDataType": "int",
+          "columnDataType": "varchar(50)",
           "columnName": "fileName",
           "defaultValue": "Something Else",
           "defaultValueBoolean": true,
           "defaultValueComputed": "now",
-          "defaultValueDate": "A String",
-          "defaultValueNumeric": "A String",
+          "defaultValueConstraintName": "A String",
+          "defaultValueDate": "2008-02-12T12:34:03",
+          "defaultValueNumeric": "439.2",
           "defaultValueSequenceNext": "seq_name",
           "schemaName": "public",
           "tableName": "file"
@@ -123,11 +131,14 @@ ALTER TABLE cat.file ALTER fileName SET DEFAULT 'Something Else';
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_foreign_key_constraint.md
+++ b/documentation/changes/add_foreign_key_constraint.md
@@ -26,15 +26,16 @@ Adds a foreign key constraint to an existing column
 <tr><td style='vertical-align: top'>baseTableName</td><td style='vertical-align: top'>Name of the table containing the column to constrain</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>baseTableSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the new foreign key constraint</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>deferrable</td><td style='vertical-align: top'>Is the foreign key deferrable</td><td style='vertical-align: top'></td><td style='vertical-align:top'>postgresql, oracle</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>initiallyDeferred</td><td style='vertical-align: top'>Is the foreign key initially deferred</td><td style='vertical-align: top'></td><td style='vertical-align:top'>postgresql, oracle</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>onDelete</td><td style='vertical-align: top'>ON DELETE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>deferrable</td><td style='vertical-align: top'>Is the foreign key deferrable</td><td style='vertical-align: top'></td><td style='vertical-align:top'>oracle, sqlite, postgresql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>initiallyDeferred</td><td style='vertical-align: top'>Is the foreign key initially deferred</td><td style='vertical-align: top'></td><td style='vertical-align:top'>oracle, sqlite, postgresql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>onDelete</td><td style='vertical-align: top'>ON DELETE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'</td><td style='vertical-align: top'></td><td style='vertical-align:top'>firebird, oracle, hsqldb, db2z, h2, informix, mariadb, postgresql, ingres, db2, asany, derby, mysql, mssql</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>onUpdate</td><td style='vertical-align: top'>ON UPDATE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>referencedColumnNames</td><td style='vertical-align: top'>Column(s) the foreign key points to. Comma-separate if multiple</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>referencedTableCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
 <tr><td style='vertical-align: top'>referencedTableName</td><td style='vertical-align: top'>Name of the table the foreign key points to</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>referencedTableSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>referencesUniqueColumn</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>validate</td><td style='vertical-align: top'>This is true if the foreign key has 'ENABLE VALIDATE' set, or false if the foreign key has 'ENABLE NOVALIDATE' set.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -45,16 +46,23 @@ Adds a foreign key constraint to an existing column
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addForeignKeyConstraint-example">
+<changeSet author="liquibase-docs"
+        id="addForeignKeyConstraint-example"
+        objectQuotingStrategy="LEGACY">
     <addForeignKeyConstraint baseColumnNames="person_id"
+            baseTableCatalogName="cat"
             baseTableName="address"
+            baseTableSchemaName="public"
             constraintName="fk_address_person"
             deferrable="true"
             initiallyDeferred="true"
             onDelete="CASCADE"
             onUpdate="RESTRICT"
             referencedColumnNames="id"
-            referencedTableName="person"/>
+            referencedTableCatalogName="cat"
+            referencedTableName="person"
+            referencedTableSchemaName="public"
+            validate="true"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -63,17 +71,23 @@ Adds a foreign key constraint to an existing column
 changeSet:
   id: addForeignKeyConstraint-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addForeignKeyConstraint:
       baseColumnNames: person_id
+      baseTableCatalogName: cat
       baseTableName: address
+      baseTableSchemaName: public
       constraintName: fk_address_person
       deferrable: true
       initiallyDeferred: true
       onDelete: CASCADE
       onUpdate: RESTRICT
       referencedColumnNames: id
+      referencedTableCatalogName: cat
       referencedTableName: person
+      referencedTableSchemaName: public
+      validate: true
 
 {% endhighlight %}
 </div>
@@ -83,18 +97,24 @@ changeSet:
   "changeSet": {
     "id": "addForeignKeyConstraint-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addForeignKeyConstraint": {
           "baseColumnNames": "person_id",
+          "baseTableCatalogName": "cat",
           "baseTableName": "address",
+          "baseTableSchemaName": "public",
           "constraintName": "fk_address_person",
           "deferrable": true,
           "initiallyDeferred": true,
           "onDelete": "CASCADE",
           "onUpdate": "RESTRICT",
           "referencedColumnNames": "id",
-          "referencedTableName": "person"
+          "referencedTableCatalogName": "cat",
+          "referencedTableName": "person",
+          "referencedTableSchemaName": "public",
+          "validate": true
         }
       }]
     
@@ -109,7 +129,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE address ADD CONSTRAINT fk_address_person FOREIGN KEY (person_id) REFERENCES person (id) ON UPDATE RESTRICT ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+ALTER TABLE cat.address ADD CONSTRAINT fk_address_person FOREIGN KEY (person_id) REFERENCES cat.person (id) ON UPDATE RESTRICT ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
 
 {% endhighlight %}
@@ -119,11 +139,14 @@ ALTER TABLE address ADD CONSTRAINT fk_address_person FOREIGN KEY (person_id) REF
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_lookup_table.md
+++ b/documentation/changes/add_lookup_table.md
@@ -26,7 +26,7 @@ Creates a lookup table containing values stored in a column and creates a foreig
 <tr><td style='vertical-align: top'>existingTableCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>existingTableName</td><td style='vertical-align: top'>Name of the table containing the data to extract</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>existingTableSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>newColumnDataType</td><td style='vertical-align: top'>Data type of the new table column</td><td style='vertical-align: top'>informix, mssql, h2, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>newColumnDataType</td><td style='vertical-align: top'>Data type of the new table column</td><td style='vertical-align: top'>informix, mariadb, mysql, mssql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>newColumnName</td><td style='vertical-align: top'>Name of the column in the new table to create</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>newTableCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
 <tr><td style='vertical-align: top'>newTableName</td><td style='vertical-align: top'>Name of lookup table to create</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
@@ -41,13 +41,17 @@ Creates a lookup table containing values stored in a column and creates a foreig
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addLookupTable-example">
+<changeSet author="liquibase-docs"
+        id="addLookupTable-example"
+        objectQuotingStrategy="LEGACY">
     <addLookupTable constraintName="fk_address_state"
             existingColumnName="state"
             existingTableName="address"
             newColumnDataType="char(2)"
             newColumnName="abbreviation"
-            newTableName="state"/>
+            newTableCatalogName="cat"
+            newTableName="state"
+            newTableSchemaName="public"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -56,6 +60,7 @@ Creates a lookup table containing values stored in a column and creates a foreig
 changeSet:
   id: addLookupTable-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addLookupTable:
       constraintName: fk_address_state
@@ -63,7 +68,9 @@ changeSet:
       existingTableName: address
       newColumnDataType: char(2)
       newColumnName: abbreviation
+      newTableCatalogName: cat
       newTableName: state
+      newTableSchemaName: public
 
 {% endhighlight %}
 </div>
@@ -73,6 +80,7 @@ changeSet:
   "changeSet": {
     "id": "addLookupTable-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addLookupTable": {
@@ -81,7 +89,9 @@ changeSet:
           "existingTableName": "address",
           "newColumnDataType": "char(2)",
           "newColumnName": "abbreviation",
-          "newTableName": "state"
+          "newTableCatalogName": "cat",
+          "newTableName": "state",
+          "newTableSchemaName": "public"
         }
       }]
     
@@ -96,13 +106,13 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-CREATE TABLE state AS SELECT DISTINCT state AS abbreviation FROM address WHERE state IS NOT NULL;
+CREATE TABLE cat.state AS SELECT DISTINCT state AS abbreviation FROM address WHERE state IS NOT NULL;
 
-ALTER TABLE state MODIFY abbreviation CHAR(2) NOT NULL;
+ALTER TABLE public.state MODIFY abbreviation CHAR(2) NOT NULL;
 
-ALTER TABLE state ADD PRIMARY KEY (abbreviation);
+ALTER TABLE public.state ADD PRIMARY KEY (abbreviation);
 
-ALTER TABLE address ADD CONSTRAINT fk_address_state FOREIGN KEY (state) REFERENCES state (abbreviation);
+ALTER TABLE address ADD CONSTRAINT fk_address_state FOREIGN KEY (state) REFERENCES public.state (abbreviation);
 
 
 {% endhighlight %}
@@ -112,11 +122,14 @@ ALTER TABLE address ADD CONSTRAINT fk_address_state FOREIGN KEY (state) REFERENC
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>HyperSQL</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_not_null_constraint.md
+++ b/documentation/changes/add_not_null_constraint.md
@@ -22,11 +22,13 @@ Adds a not-null constraint to an existing table. If a defaultNullValue attribute
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Current data type of the column</td><td style='vertical-align: top'>informix, mssql, h2, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Current data type of the column</td><td style='vertical-align: top'>informix, mariadb, mysql, mssql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column to add the constraint to</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Created constraint name (if database supports names for NOT NULL constraints)</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>defaultNullValue</td><td style='vertical-align: top'>Value to set all currently null values to. If not set, change will fail if null values exist</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Adds a not-null constraint to an existing table. If a defaultNullValue attribute is passed, all null values for the column will be updated to the passed value before the constraint is applied.</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>validate</td><td style='vertical-align: top'>This is true if the not null constraint has 'ENABLE VALIDATE' set, or false if the not null constrain has 'ENABLE NOVALIDATE' set.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -37,13 +39,17 @@ Adds a not-null constraint to an existing table. If a defaultNullValue attribute
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addNotNullConstraint-example">
+<changeSet author="liquibase-docs"
+        id="addNotNullConstraint-example"
+        objectQuotingStrategy="LEGACY">
     <addNotNullConstraint catalogName="cat"
             columnDataType="int"
             columnName="id"
+            constraintName="const_name"
             defaultNullValue="A String"
             schemaName="public"
-            tableName="person"/>
+            tableName="person"
+            validate="true"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -52,14 +58,17 @@ Adds a not-null constraint to an existing table. If a defaultNullValue attribute
 changeSet:
   id: addNotNullConstraint-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addNotNullConstraint:
       catalogName: cat
       columnDataType: int
       columnName: id
+      constraintName: const_name
       defaultNullValue: A String
       schemaName: public
       tableName: person
+      validate: true
 
 {% endhighlight %}
 </div>
@@ -69,15 +78,18 @@ changeSet:
   "changeSet": {
     "id": "addNotNullConstraint-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addNotNullConstraint": {
           "catalogName": "cat",
           "columnDataType": "int",
           "columnName": "id",
+          "constraintName": "const_name",
           "defaultNullValue": "A String",
           "schemaName": "public",
-          "tableName": "person"
+          "tableName": "person",
+          "validate": true
         }
       }]
     
@@ -103,12 +115,15 @@ ALTER TABLE cat.person MODIFY id INT NOT NULL;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
+<tr><td>DB2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_primary_key.md
+++ b/documentation/changes/add_primary_key.md
@@ -22,11 +22,16 @@ Adds creates a primary key out of an existing column or set of columns.
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
+<tr><td style='vertical-align: top'>clustered</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>columnNames</td><td style='vertical-align: top'>Name of the column(s) to create the primary key on. Comma separated if multiple</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of primary key constraint</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>oracle, db2, db2z</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to create the primary key on</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tablespace</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>validate</td><td style='vertical-align: top'>This is true if the primary key has 'ENABLE VALIDATE' set, or false if the primary key has 'ENABLE NOVALIDATE' set.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -37,13 +42,18 @@ Adds creates a primary key out of an existing column or set of columns.
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addPrimaryKey-example">
+<changeSet author="liquibase-docs"
+        id="addPrimaryKey-example"
+        objectQuotingStrategy="LEGACY">
     <addPrimaryKey catalogName="cat"
+            clustered="true"
             columnNames="id, name"
             constraintName="pk_person"
+            forIndexName="A String"
             schemaName="public"
             tableName="person"
-            tablespace="A String"/>
+            tablespace="A String"
+            validate="true"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -52,14 +62,18 @@ Adds creates a primary key out of an existing column or set of columns.
 changeSet:
   id: addPrimaryKey-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addPrimaryKey:
       catalogName: cat
+      clustered: true
       columnNames: id, name
       constraintName: pk_person
+      forIndexName: A String
       schemaName: public
       tableName: person
       tablespace: A String
+      validate: true
 
 {% endhighlight %}
 </div>
@@ -69,15 +83,19 @@ changeSet:
   "changeSet": {
     "id": "addPrimaryKey-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addPrimaryKey": {
           "catalogName": "cat",
+          "clustered": true,
           "columnNames": "id, name",
           "constraintName": "pk_person",
+          "forIndexName": "A String",
           "schemaName": "public",
           "tableName": "person",
-          "tablespace": "A String"
+          "tablespace": "A String",
+          "validate": true
         }
       }]
     
@@ -103,11 +121,14 @@ ALTER TABLE cat.person ADD PRIMARY KEY (id,
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/add_unique_constraint.md
+++ b/documentation/changes/add_unique_constraint.md
@@ -22,14 +22,19 @@ Adds a unique constrant to an existing column or set of columns.
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
+<tr><td style='vertical-align: top'>clustered</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>mssql</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>columnNames</td><td style='vertical-align: top'>Name of the column(s) to create the unique constraint on. Comma separated if multiple</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the unique constraint</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>deferrable</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>disabled</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>initiallyDeferred</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>deferrable</td><td style='vertical-align: top'>True if this constraint is deferrable, False otherwise</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>disabled</td><td style='vertical-align: top'>True if this constraint is disabled, False otherwise</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>oracle</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>forIndexSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>initiallyDeferred</td><td style='vertical-align: top'>True if this constraint is initially deferred, False otherwise</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to create the unique constraint on</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tablespace</td><td style='vertical-align: top'>'Tablespace' to create the index in. Corresponds to file group in mssql</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>validate</td><td style='vertical-align: top'>This is true if the unique constraint has 'ENABLE VALIDATE' set, or false if the foreign key has 'ENABLE NOVALIDATE' set.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -40,16 +45,21 @@ Adds a unique constrant to an existing column or set of columns.
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="addUniqueConstraint-example">
+<changeSet author="liquibase-docs"
+        id="addUniqueConstraint-example"
+        objectQuotingStrategy="LEGACY">
     <addUniqueConstraint catalogName="cat"
+            clustered="true"
             columnNames="id, name"
             constraintName="const_name"
             deferrable="true"
             disabled="true"
+            forIndexName="A String"
             initiallyDeferred="true"
             schemaName="public"
             tableName="person"
-            tablespace="A String"/>
+            tablespace="A String"
+            validate="true"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -58,17 +68,21 @@ Adds a unique constrant to an existing column or set of columns.
 changeSet:
   id: addUniqueConstraint-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - addUniqueConstraint:
       catalogName: cat
+      clustered: true
       columnNames: id, name
       constraintName: const_name
       deferrable: true
       disabled: true
+      forIndexName: A String
       initiallyDeferred: true
       schemaName: public
       tableName: person
       tablespace: A String
+      validate: true
 
 {% endhighlight %}
 </div>
@@ -78,18 +92,22 @@ changeSet:
   "changeSet": {
     "id": "addUniqueConstraint-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "addUniqueConstraint": {
           "catalogName": "cat",
+          "clustered": true,
           "columnNames": "id, name",
           "constraintName": "const_name",
           "deferrable": true,
           "disabled": true,
+          "forIndexName": "A String",
           "initiallyDeferred": true,
           "schemaName": "public",
           "tableName": "person",
-          "tablespace": "A String"
+          "tablespace": "A String",
+          "validate": true
         }
       }]
     
@@ -104,8 +122,8 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person ADD CONSTRAINT const_name UNIQUE (id,
- name);
+ALTER TABLE cat.person ADD CONSTRAINT const_name UNIQUE CLUSTERED (id,
+ name) USING INDEX `A String`;
 
 
 {% endhighlight %}
@@ -115,11 +133,14 @@ ALTER TABLE cat.person ADD CONSTRAINT const_name UNIQUE (id,
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/alter_sequence.md
+++ b/documentation/changes/alter_sequence.md
@@ -21,11 +21,13 @@ Alter properties of an existing sequence
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
+<tr><td style='vertical-align: top'>cacheSize</td><td style='vertical-align: top'>Change the cache size?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>incrementBy</td><td style='vertical-align: top'>New amount the sequence should increment by</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, postgresql, db2, oracle, firebird</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>maxValue</td><td style='vertical-align: top'>New maximum value for the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, postgresql, db2, oracle, firebird</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>minValue</td><td style='vertical-align: top'>New minimum value for the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, hsqldb, postgresql, db2, oracle, firebird</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>ordered</td><td style='vertical-align: top'>Does the sequence need to be guaranteed to be genererated inm the order of request?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, hsqldb, postgresql, oracle, firebird, h2</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>cycle</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>incrementBy</td><td style='vertical-align: top'>New amount the sequence should increment by</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, firebird, oracle, postgresql, db2, asany, db2z, derby, mssql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>maxValue</td><td style='vertical-align: top'>New maximum value for the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, firebird, oracle, postgresql, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>minValue</td><td style='vertical-align: top'>New minimum value for the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>ordered</td><td style='vertical-align: top'>Does the sequence need to be guaranteed to be genererated inm the order of request?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, firebird, oracle, postgresql, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>sequenceName</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
@@ -38,8 +40,12 @@ Alter properties of an existing sequence
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="alterSequence-example">
-    <alterSequence catalogName="cat"
+<changeSet author="liquibase-docs"
+        id="alterSequence-example"
+        objectQuotingStrategy="LEGACY">
+    <alterSequence cacheSize="371717"
+            catalogName="cat"
+            cycle="true"
             incrementBy="371717"
             maxValue="371717"
             minValue="371717"
@@ -54,9 +60,12 @@ Alter properties of an existing sequence
 changeSet:
   id: alterSequence-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - alterSequence:
+      cacheSize: 371717
       catalogName: cat
+      cycle: true
       incrementBy: 371717
       maxValue: 371717
       minValue: 371717
@@ -72,10 +81,13 @@ changeSet:
   "changeSet": {
     "id": "alterSequence-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "alterSequence": {
+          "cacheSize": 371717,
           "catalogName": "cat",
+          "cycle": true,
           "incrementBy": 371717,
           "maxValue": 371717,
           "minValue": 371717,
@@ -93,10 +105,10 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (Oracle)
+## SQL Generated From Above Sample (SQL Server)
 
 {% highlight sql %}
-ALTER SEQUENCE cat.seq_id INCREMENT BY 371717 MINVALUE 371717 MAXVALUE 371717 ORDER;
+ALTER SEQUENCE [public].seq_id INCREMENT BY 371717 MINVALUE 371717 MAXVALUE 371717 ORDER;
 
 
 {% endhighlight %}
@@ -106,16 +118,19 @@ ALTER SEQUENCE cat.seq_id INCREMENT BY 371717 MINVALUE 371717 MAXVALUE 371717 OR
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>MySQL</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>SQL Server</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Sybase</td><td>Not Supported</td><td>No</td></tr>
-<tr><td>Sybase Anywhere</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/create_index.md
+++ b/documentation/changes/create_index.md
@@ -22,7 +22,8 @@ Creates an index on an existing column or set of columns.
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>indexName</td><td style='vertical-align: top'>Name of the index to create</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>clustered</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>indexName</td><td style='vertical-align: top'>Name of the index to create</td><td style='vertical-align: top'>firebird, hsqldb</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to add the index to</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tablespace</td><td style='vertical-align: top'>Tablepace to create the index in.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
@@ -43,14 +44,17 @@ Creates an index on an existing column or set of columns.
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="createIndex-example">
+<changeSet author="liquibase-docs"
+        id="createIndex-example"
+        objectQuotingStrategy="LEGACY">
     <createIndex catalogName="cat"
+            clustered="true"
             indexName="idx_address"
             schemaName="public"
             tableName="person"
             tablespace="A String"
             unique="true">
-        <column name="address" type="varchar(255)" descending="false"/>
+        <column name="address"/>
     </createIndex>
 </changeSet>
 {% endhighlight %}
@@ -60,14 +64,14 @@ Creates an index on an existing column or set of columns.
 changeSet:
   id: createIndex-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - createIndex:
       catalogName: cat
+      clustered: true
       columns:
       - column:
           name: address
-          type: varchar(255)
-          descending: false
       indexName: idx_address
       schemaName: public
       tableName: person
@@ -82,16 +86,16 @@ changeSet:
   "changeSet": {
     "id": "createIndex-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "createIndex": {
           "catalogName": "cat",
+          "clustered": true,
           "columns": [
             {
               "column": {
-                "name": "address",
-                "type": "varchar(255)",
-                "descending": false
+                "name": "address"
               }
             }]
           ,
@@ -124,11 +128,14 @@ CREATE UNIQUE INDEX idx_address ON cat.person(address);
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/create_procedure.md
+++ b/documentation/changes/create_procedure.md
@@ -28,9 +28,10 @@ Often times it is best to use the CREATE OR REPLACE syntax along with setting ru
 <tr><td style='vertical-align: top'>dbms</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.1</td></tr>
 <tr><td style='vertical-align: top'>encoding</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>path</td><td style='vertical-align: top'>File containing the procedure text. Either this attribute or a nested procedure text is required.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>procedureName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>procedureText</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>procedureName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>relativeToChangelogFile</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>replaceIfExists</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>mssql</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
@@ -42,14 +43,17 @@ Often times it is best to use the CREATE OR REPLACE syntax along with setting ru
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="createProcedure-example">
+<changeSet author="liquibase-docs"
+        id="createProcedure-example"
+        objectQuotingStrategy="LEGACY">
     <createProcedure catalogName="cat"
             comments="A String"
             dbms="h2, oracle"
-            encoding="utf8"
+            encoding="UTF-8"
             path="com/example/my-logic.sql"
-            procedureName="A String"
+            procedureName="new_customer"
             relativeToChangelogFile="true"
+            replaceIfExists="false"
             schemaName="public">CREATE OR REPLACE PROCEDURE testHello
     IS
     BEGIN
@@ -63,21 +67,23 @@ Often times it is best to use the CREATE OR REPLACE syntax along with setting ru
 changeSet:
   id: createProcedure-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - createProcedure:
       catalogName: cat
       comments: A String
       dbms: h2, oracle
-      encoding: utf8
+      encoding: UTF-8
       path: com/example/my-logic.sql
-      procedureName: A String
       procedureText: |-
         CREATE OR REPLACE PROCEDURE testHello
             IS
             BEGIN
               DBMS_OUTPUT.PUT_LINE('Hello From The Database!');
             END;
+      procedureName: new_customer
       relativeToChangelogFile: true
+      replaceIfExists: false
       schemaName: public
 
 {% endhighlight %}
@@ -88,18 +94,19 @@ changeSet:
   "changeSet": {
     "id": "createProcedure-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "createProcedure": {
           "catalogName": "cat",
           "comments": "A String",
           "dbms": "h2, oracle",
-          "encoding": "utf8",
+          "encoding": "UTF-8",
           "path": "com/example/my-logic.sql",
-          "procedureName": "A String",
-          "procedureText": "CREATE OR REPLACE PROCEDURE testHello\n    IS\n    BEGIN\n\
-            \      DBMS_OUTPUT.PUT_LINE('Hello From The Database!');\n    END;",
+          "procedureText": "CREATE OR REPLACE PROCEDURE testHello\n    IS\n    BEGIN\n      DBMS_OUTPUT.PUT_LINE('Hello From The Database!');\n    END;",
+          "procedureName": "new_customer",
           "relativeToChangelogFile": true,
+          "replaceIfExists": false,
           "schemaName": "public"
         }
       }]
@@ -117,11 +124,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/create_sequence.md
+++ b/documentation/changes/create_sequence.md
@@ -21,15 +21,17 @@ Creates a new database sequence
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
+<tr><td style='vertical-align: top'>cacheSize</td><td style='vertical-align: top'>Number of values to fetch per query</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
 <tr><td style='vertical-align: top'>cycle</td><td style='vertical-align: top'>Can the sequence cycle when it hits the max value?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>incrementBy</td><td style='vertical-align: top'>Interval between sequence numbers</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, hsqldb, postgresql, db2, oracle, h2</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>maxValue</td><td style='vertical-align: top'>The maximum value of the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, postgresql, db2, oracle</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>minValue</td><td style='vertical-align: top'>The minimum value of the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, postgresql, db2, oracle</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>ordered</td><td style='vertical-align: top'>Does the sequence need to be guaranteed to be genererated inm the order of request?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, hsqldb, postgresql, oracle, firebird, h2</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>dataType</td><td style='vertical-align: top'>Data type of the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>incrementBy</td><td style='vertical-align: top'>Interval between sequence numbers</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, oracle, postgresql, hsqldb, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>maxValue</td><td style='vertical-align: top'>The maximum value of the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, oracle, postgresql, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>minValue</td><td style='vertical-align: top'>The minimum value of the sequence</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, oracle, postgresql, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>ordered</td><td style='vertical-align: top'>Does the sequence need to be guaranteed to be genererated inm the order of request?</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, firebird, oracle, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>sequenceName</td><td style='vertical-align: top'>Name of the sequence to create</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>startValue</td><td style='vertical-align: top'>The first sequence number to be generated.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, hsqldb, postgresql, db2, oracle, h2</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>startValue</td><td style='vertical-align: top'>The first sequence number to be generated.</td><td style='vertical-align: top'></td><td style='vertical-align:top'>informix, oracle, postgresql, hsqldb, db2, asany, db2z, derby, h2, mssql</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -40,9 +42,13 @@ Creates a new database sequence
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="createSequence-example">
-    <createSequence catalogName="cat"
+<changeSet author="liquibase-docs"
+        id="createSequence-example"
+        objectQuotingStrategy="LEGACY">
+    <createSequence cacheSize="371717"
+            catalogName="cat"
             cycle="true"
+            dataType="int"
             incrementBy="2"
             maxValue="1000"
             minValue="10"
@@ -58,10 +64,13 @@ Creates a new database sequence
 changeSet:
   id: createSequence-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - createSequence:
+      cacheSize: 371717
       catalogName: cat
       cycle: true
+      dataType: int
       incrementBy: 2
       maxValue: 1000
       minValue: 10
@@ -78,11 +87,14 @@ changeSet:
   "changeSet": {
     "id": "createSequence-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "createSequence": {
+          "cacheSize": 371717,
           "catalogName": "cat",
           "cycle": true,
+          "dataType": "int",
           "incrementBy": 2,
           "maxValue": 1000,
           "minValue": 10,
@@ -101,10 +113,10 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (Oracle)
+## SQL Generated From Above Sample (SQL Server)
 
 {% highlight sql %}
-CREATE SEQUENCE cat.seq_id START WITH 5 INCREMENT BY 2 MINVALUE 10 MAXVALUE 1000 ORDER CYCLE;
+CREATE SEQUENCE [public].seq_id START WITH 5 INCREMENT BY 2 MINVALUE 10 MAXVALUE 1000 ORDER CYCLE;
 
 
 {% endhighlight %}
@@ -114,16 +126,19 @@ CREATE SEQUENCE cat.seq_id START WITH 5 INCREMENT BY 2 MINVALUE 10 MAXVALUE 1000
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>Derby</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>SQL Server</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>SQL Server</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Sybase</td><td>Not Supported</td><td><b>Yes</b></td></tr>
-<tr><td>Sybase Anywhere</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 </table>

--- a/documentation/changes/create_table.md
+++ b/documentation/changes/create_table.md
@@ -42,7 +42,9 @@ Create Table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="createTable-example">
+<changeSet author="liquibase-docs"
+        id="createTable-example"
+        objectQuotingStrategy="LEGACY">
     <createTable catalogName="cat"
             remarks="A String"
             schemaName="public"
@@ -58,6 +60,7 @@ Create Table
 changeSet:
   id: createTable-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - createTable:
       catalogName: cat
@@ -78,6 +81,7 @@ changeSet:
   "changeSet": {
     "id": "createTable-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "createTable": {
@@ -120,11 +124,14 @@ ALTER TABLE cat.person COMMENT = 'A String';
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/create_view.md
+++ b/documentation/changes/create_view.md
@@ -22,9 +22,14 @@ Create a new database view
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>replaceIfExists</td><td style='vertical-align: top'>Use 'create or replace' syntax</td><td style='vertical-align: top'></td><td style='vertical-align:top'>sybase, mssql, postgresql, oracle, firebird, sqlite, h2, mysql</td><td style='vertical-align: top'>1.5</td></tr>
+<tr><td style='vertical-align: top'>encoding</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>fullDefinition</td><td style='vertical-align: top'>Set to true if selectQuery is the entire view definition. False if the CREATE VIEW header should be added</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.3</td></tr>
+<tr><td style='vertical-align: top'>path</td><td style='vertical-align: top'>Path to file containing view definition</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.6</td></tr>
+<tr><td style='vertical-align: top'>relativeToChangelogFile</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>remarks</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>replaceIfExists</td><td style='vertical-align: top'>Use 'create or replace' syntax</td><td style='vertical-align: top'></td><td style='vertical-align:top'>mariadb, firebird, sybase, oracle, sqlite, postgresql, hsqldb, ingres, db2, h2, mysql, mssql</td><td style='vertical-align: top'>1.5</td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>selectQuery</td><td style='vertical-align: top'>SQL for generating the view</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>selectQuery</td><td style='vertical-align: top'>SQL for generating the view</td><td style='vertical-align: top'>informix</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>viewName</td><td style='vertical-align: top'>Name of the view to create</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
@@ -36,9 +41,16 @@ Create a new database view
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="createView-example">
+<changeSet author="liquibase-docs"
+        id="createView-example"
+        objectQuotingStrategy="LEGACY">
     <createView catalogName="cat"
-            replaceIfExists="true"
+            encoding="UTF-8"
+            fullDefinition="true"
+            path="A String"
+            relativeToChangelogFile="true"
+            remarks="A String"
+            replaceIfExists="false"
             schemaName="public"
             viewName="v_person">select id, name from person where id > 10</createView>
 </changeSet>
@@ -49,10 +61,16 @@ Create a new database view
 changeSet:
   id: createView-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - createView:
       catalogName: cat
-      replaceIfExists: true
+      encoding: UTF-8
+      fullDefinition: true
+      path: A String
+      relativeToChangelogFile: true
+      remarks: A String
+      replaceIfExists: false
       schemaName: public
       selectQuery: select id, name from person where id > 10
       viewName: v_person
@@ -65,11 +83,17 @@ changeSet:
   "changeSet": {
     "id": "createView-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "createView": {
           "catalogName": "cat",
-          "replaceIfExists": true,
+          "encoding": "UTF-8",
+          "fullDefinition": true,
+          "path": "A String",
+          "relativeToChangelogFile": true,
+          "remarks": "A String",
+          "replaceIfExists": false,
           "schemaName": "public",
           "selectQuery": "select id, name from person where id > 10",
           "viewName": "v_person"
@@ -87,7 +111,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-CREATE OR REPLACE VIEW cat.v_person AS select id,
+CREATE VIEW cat.v_person AS select id,
  name from person where id > 10;
 
 
@@ -98,11 +122,14 @@ CREATE OR REPLACE VIEW cat.v_person AS select id,
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/custom_change.md
+++ b/documentation/changes/custom_change.md
@@ -37,7 +37,9 @@ For a sample custom change class, see liquibase.change.custom.ExampleCustomSqlCh
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="customChange-example">
+<changeSet author="liquibase-docs"
+        id="customChange-example"
+        objectQuotingStrategy="LEGACY">
     <customChange/>
 </changeSet>
 {% endhighlight %}
@@ -47,9 +49,9 @@ For a sample custom change class, see liquibase.change.custom.ExampleCustomSqlCh
 changeSet:
   id: customChange-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
-  - customChange:
-      param: {}
+  - customChange: {}
 
 {% endhighlight %}
 </div>
@@ -59,12 +61,11 @@ changeSet:
   "changeSet": {
     "id": "customChange-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "customChange": {
-          "param": {
-            }
-        }
+          }
       }]
     
   }
@@ -80,11 +81,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/delete.md
+++ b/documentation/changes/delete.md
@@ -35,11 +35,13 @@ Deletes data from an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="delete-example">
+<changeSet author="liquibase-docs"
+        id="delete-example"
+        objectQuotingStrategy="LEGACY">
     <delete catalogName="cat"
             schemaName="public"
             tableName="person">
-        <where>A String</where>
+        <where>name='Bob'</where>
     </delete>
 </changeSet>
 {% endhighlight %}
@@ -49,12 +51,13 @@ Deletes data from an existing table
 changeSet:
   id: delete-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - delete:
       catalogName: cat
       schemaName: public
       tableName: person
-      where: A String
+      where: name='Bob'
 
 {% endhighlight %}
 </div>
@@ -64,13 +67,14 @@ changeSet:
   "changeSet": {
     "id": "delete-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "delete": {
           "catalogName": "cat",
           "schemaName": "public",
           "tableName": "person",
-          "where": "A String"
+          "where": "name='Bob'"
         }
       }]
     
@@ -85,7 +89,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-DELETE FROM cat.person  WHERE A String;
+DELETE FROM cat.person WHERE name='Bob';
 
 
 {% endhighlight %}
@@ -95,11 +99,14 @@ DELETE FROM cat.person  WHERE A String;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_all_foreign_key_constraints.md
+++ b/documentation/changes/drop_all_foreign_key_constraints.md
@@ -34,8 +34,12 @@ Drops all foreign key constraints for a table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropAllForeignKeyConstraints-example">
-    <dropAllForeignKeyConstraints baseTableName="person"/>
+<changeSet author="liquibase-docs"
+        id="dropAllForeignKeyConstraints-example"
+        objectQuotingStrategy="LEGACY">
+    <dropAllForeignKeyConstraints baseTableCatalogName="cat"
+            baseTableName="person"
+            baseTableSchemaName="public"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -44,9 +48,12 @@ Drops all foreign key constraints for a table
 changeSet:
   id: dropAllForeignKeyConstraints-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropAllForeignKeyConstraints:
+      baseTableCatalogName: cat
       baseTableName: person
+      baseTableSchemaName: public
 
 {% endhighlight %}
 </div>
@@ -56,10 +63,13 @@ changeSet:
   "changeSet": {
     "id": "dropAllForeignKeyConstraints-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropAllForeignKeyConstraints": {
-          "baseTableName": "person"
+          "baseTableCatalogName": "cat",
+          "baseTableName": "person",
+          "baseTableSchemaName": "public"
         }
       }]
     
@@ -76,11 +86,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_column.md
+++ b/documentation/changes/drop_column.md
@@ -15,18 +15,24 @@ title: Change dropColumn
 
 # Change: 'dropColumn'
 
-Drop an existing column
+Drop existing column(s)
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column to drop</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column to drop</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table containing the column to drop</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
+## Nested Properties ##
+
+<table>
+<tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Multiple&nbsp;Allowed</th><th>Since</th></tr>
+<tr><td style='vertical-align: top'>columns</td><td style='vertical-align: top'>Columns to be dropped.<br><br>See the <a href='../column.html'>column tag</a> documentation for more information</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align: top'>yes</td><td style='vertical-align: top'></td></tr>
+</table>
 <div id='changelog-tabs'>
 <ul>
     <li><a href="#tab-xml">XML Sample</a></li>
@@ -35,11 +41,15 @@ Drop an existing column
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropColumn-example">
+<changeSet author="liquibase-docs"
+        id="dropColumn-example"
+        objectQuotingStrategy="LEGACY">
     <dropColumn catalogName="cat"
             columnName="id"
             schemaName="public"
-            tableName="person"/>
+            tableName="person">
+        <column name="address" type="varchar(255)"/>
+    </dropColumn>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -48,10 +58,15 @@ Drop an existing column
 changeSet:
   id: dropColumn-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropColumn:
       catalogName: cat
       columnName: id
+      columns:
+      - column:
+          name: address
+          type: varchar(255)
       schemaName: public
       tableName: person
 
@@ -63,11 +78,20 @@ changeSet:
   "changeSet": {
     "id": "dropColumn-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropColumn": {
           "catalogName": "cat",
           "columnName": "id",
+          "columns": [
+            {
+              "column": {
+                "name": "address",
+                "type": "varchar(255)"
+              }
+            }]
+          ,
           "schemaName": "public",
           "tableName": "person"
         }
@@ -84,7 +108,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person DROP COLUMN id;
+ALTER TABLE cat.person DROP COLUMN address;
 
 
 {% endhighlight %}
@@ -93,12 +117,15 @@ ALTER TABLE cat.person DROP COLUMN id;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
+<tr><td>DB2</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_default_value.md
+++ b/documentation/changes/drop_default_value.md
@@ -36,7 +36,9 @@ Removes the database default value for a column
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropDefaultValue-example">
+<changeSet author="liquibase-docs"
+        id="dropDefaultValue-example"
+        objectQuotingStrategy="LEGACY">
     <dropDefaultValue catalogName="cat"
             columnDataType="int"
             columnName="id"
@@ -50,6 +52,7 @@ Removes the database default value for a column
 changeSet:
   id: dropDefaultValue-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropDefaultValue:
       catalogName: cat
@@ -66,6 +69,7 @@ changeSet:
   "changeSet": {
     "id": "dropDefaultValue-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropDefaultValue": {
@@ -98,11 +102,14 @@ ALTER TABLE cat.person ALTER id DROP DEFAULT;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_foreign_key_constraint.md
+++ b/documentation/changes/drop_foreign_key_constraint.md
@@ -22,9 +22,9 @@ Drops an existing foreign key
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>baseTableCatalogName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>baseTableName</td><td style='vertical-align: top'>Name of the table containing the column constrained by the foreign key</td><td style='vertical-align: top'>informix, sybase, unsupported, asany, postgresql, firebird, oracle, mssql, hsqldb, db2, mysql, h2, derby</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>baseTableName</td><td style='vertical-align: top'>Name of the table containing the column constrained by the foreign key</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>baseTableSchemaName</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the foreign key constraint to drop</td><td style='vertical-align: top'>informix, sybase, unsupported, asany, postgresql, firebird, oracle, mssql, hsqldb, db2, mysql, h2, derby</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the foreign key constraint to drop</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -35,8 +35,13 @@ Drops an existing foreign key
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropForeignKeyConstraint-example">
-    <dropForeignKeyConstraint baseTableName="person" constraintName="fk_address_person"/>
+<changeSet author="liquibase-docs"
+        id="dropForeignKeyConstraint-example"
+        objectQuotingStrategy="LEGACY">
+    <dropForeignKeyConstraint baseTableCatalogName="cat"
+            baseTableName="person"
+            baseTableSchemaName="public"
+            constraintName="fk_address_person"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -45,9 +50,12 @@ Drops an existing foreign key
 changeSet:
   id: dropForeignKeyConstraint-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropForeignKeyConstraint:
+      baseTableCatalogName: cat
       baseTableName: person
+      baseTableSchemaName: public
       constraintName: fk_address_person
 
 {% endhighlight %}
@@ -58,10 +66,13 @@ changeSet:
   "changeSet": {
     "id": "dropForeignKeyConstraint-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropForeignKeyConstraint": {
+          "baseTableCatalogName": "cat",
           "baseTableName": "person",
+          "baseTableSchemaName": "public",
           "constraintName": "fk_address_person"
         }
       }]
@@ -77,7 +88,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE person DROP FOREIGN KEY fk_address_person;
+ALTER TABLE cat.person DROP FOREIGN KEY fk_address_person;
 
 
 {% endhighlight %}
@@ -87,16 +98,19 @@ ALTER TABLE person DROP FOREIGN KEY fk_address_person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>SQLite</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Sybase</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/drop_index.md
+++ b/documentation/changes/drop_index.md
@@ -24,7 +24,7 @@ Drops an existing index
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
 <tr><td style='vertical-align: top'>indexName</td><td style='vertical-align: top'>Name of the index to drop</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name fo the indexed table.</td><td style='vertical-align: top'>mssql, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name fo the indexed table.</td><td style='vertical-align: top'>mariadb, sybase, asany, mysql, mssql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -35,7 +35,9 @@ Drops an existing index
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropIndex-example">
+<changeSet author="liquibase-docs"
+        id="dropIndex-example"
+        objectQuotingStrategy="LEGACY">
     <dropIndex catalogName="cat"
             indexName="idx_address"
             schemaName="public"
@@ -48,6 +50,7 @@ Drops an existing index
 changeSet:
   id: dropIndex-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropIndex:
       catalogName: cat
@@ -63,6 +66,7 @@ changeSet:
   "changeSet": {
     "id": "dropIndex-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropIndex": {
@@ -94,11 +98,14 @@ DROP INDEX idx_address ON cat.person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_primary_key.md
+++ b/documentation/changes/drop_primary_key.md
@@ -22,7 +22,8 @@ Drops an existing primary key
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the primary key</td><td style='vertical-align: top'>informix, firebird</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>constraintName</td><td style='vertical-align: top'>Name of the primary key</td><td style='vertical-align: top'>informix, firebird, sybase</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>dropIndex</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to drop the primary key of</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
@@ -35,9 +36,12 @@ Drops an existing primary key
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropPrimaryKey-example">
+<changeSet author="liquibase-docs"
+        id="dropPrimaryKey-example"
+        objectQuotingStrategy="LEGACY">
     <dropPrimaryKey catalogName="cat"
             constraintName="const_name"
+            dropIndex="true"
             schemaName="public"
             tableName="person"/>
 </changeSet>
@@ -48,10 +52,12 @@ Drops an existing primary key
 changeSet:
   id: dropPrimaryKey-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropPrimaryKey:
       catalogName: cat
       constraintName: const_name
+      dropIndex: true
       schemaName: public
       tableName: person
 
@@ -63,11 +69,13 @@ changeSet:
   "changeSet": {
     "id": "dropPrimaryKey-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropPrimaryKey": {
           "catalogName": "cat",
           "constraintName": "const_name",
+          "dropIndex": true,
           "schemaName": "public",
           "tableName": "person"
         }
@@ -94,11 +102,14 @@ ALTER TABLE cat.person DROP PRIMARY KEY;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_procedure.md
+++ b/documentation/changes/drop_procedure.md
@@ -34,9 +34,11 @@ Drops an existing procedure
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropProcedure-example">
+<changeSet author="liquibase-docs"
+        id="dropProcedure-example"
+        objectQuotingStrategy="LEGACY">
     <dropProcedure catalogName="cat"
-            procedureName="full_name"
+            procedureName="new_customer"
             schemaName="public"/>
 </changeSet>
 {% endhighlight %}
@@ -46,10 +48,11 @@ Drops an existing procedure
 changeSet:
   id: dropProcedure-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropProcedure:
       catalogName: cat
-      procedureName: full_name
+      procedureName: new_customer
       schemaName: public
 
 {% endhighlight %}
@@ -60,11 +63,12 @@ changeSet:
   "changeSet": {
     "id": "dropProcedure-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropProcedure": {
           "catalogName": "cat",
-          "procedureName": "full_name",
+          "procedureName": "new_customer",
           "schemaName": "public"
         }
       }]
@@ -80,7 +84,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-DROP PROCEDURE cat.full_name;
+DROP PROCEDURE cat.new_customer;
 
 
 {% endhighlight %}
@@ -90,11 +94,14 @@ DROP PROCEDURE cat.full_name;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_sequence.md
+++ b/documentation/changes/drop_sequence.md
@@ -34,7 +34,9 @@ Drop an existing sequence
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropSequence-example">
+<changeSet author="liquibase-docs"
+        id="dropSequence-example"
+        objectQuotingStrategy="LEGACY">
     <dropSequence catalogName="cat"
             schemaName="public"
             sequenceName="seq_id"/>
@@ -46,6 +48,7 @@ Drop an existing sequence
 changeSet:
   id: dropSequence-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropSequence:
       catalogName: cat
@@ -60,6 +63,7 @@ changeSet:
   "changeSet": {
     "id": "dropSequence-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropSequence": {
@@ -77,10 +81,10 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (Oracle)
+## SQL Generated From Above Sample (SQL Server)
 
 {% highlight sql %}
-DROP SEQUENCE cat.seq_id;
+DROP SEQUENCE [public].seq_id;
 
 
 {% endhighlight %}
@@ -90,16 +94,19 @@ DROP SEQUENCE cat.seq_id;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>MySQL</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>SQL Server</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Sybase</td><td>Not Supported</td><td>No</td></tr>
-<tr><td>Sybase Anywhere</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/drop_table.md
+++ b/documentation/changes/drop_table.md
@@ -35,7 +35,9 @@ Drops an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropTable-example">
+<changeSet author="liquibase-docs"
+        id="dropTable-example"
+        objectQuotingStrategy="LEGACY">
     <dropTable cascadeConstraints="true"
             catalogName="cat"
             schemaName="public"
@@ -48,6 +50,7 @@ Drops an existing table
 changeSet:
   id: dropTable-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropTable:
       cascadeConstraints: true
@@ -63,6 +66,7 @@ changeSet:
   "changeSet": {
     "id": "dropTable-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropTable": {
@@ -94,11 +98,14 @@ DROP TABLE cat.person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_unique_constraint.md
+++ b/documentation/changes/drop_unique_constraint.md
@@ -36,12 +36,14 @@ Drops an existing unique constraint
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropUniqueConstraint-example">
+<changeSet author="liquibase-docs"
+        id="dropUniqueConstraint-example"
+        objectQuotingStrategy="LEGACY">
     <dropUniqueConstraint catalogName="cat"
             constraintName="const_name"
             schemaName="public"
             tableName="person"
-            uniqueColumns="A String"/>
+            uniqueColumns="name"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -50,13 +52,14 @@ Drops an existing unique constraint
 changeSet:
   id: dropUniqueConstraint-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropUniqueConstraint:
       catalogName: cat
       constraintName: const_name
       schemaName: public
       tableName: person
-      uniqueColumns: A String
+      uniqueColumns: name
 
 {% endhighlight %}
 </div>
@@ -66,6 +69,7 @@ changeSet:
   "changeSet": {
     "id": "dropUniqueConstraint-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropUniqueConstraint": {
@@ -73,7 +77,7 @@ changeSet:
           "constraintName": "const_name",
           "schemaName": "public",
           "tableName": "person",
-          "uniqueColumns": "A String"
+          "uniqueColumns": "name"
         }
       }]
     
@@ -98,11 +102,14 @@ ALTER TABLE cat.person DROP KEY const_name;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/drop_view.md
+++ b/documentation/changes/drop_view.md
@@ -34,7 +34,9 @@ Drops an existing view
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="dropView-example">
+<changeSet author="liquibase-docs"
+        id="dropView-example"
+        objectQuotingStrategy="LEGACY">
     <dropView catalogName="cat"
             schemaName="public"
             viewName="v_person"/>
@@ -46,6 +48,7 @@ Drops an existing view
 changeSet:
   id: dropView-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - dropView:
       catalogName: cat
@@ -60,6 +63,7 @@ changeSet:
   "changeSet": {
     "id": "dropView-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "dropView": {
@@ -90,11 +94,14 @@ DROP VIEW cat.v_person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/empty.md
+++ b/documentation/changes/empty.md
@@ -31,7 +31,9 @@ empty
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="empty-example">
+<changeSet author="liquibase-docs"
+        id="empty-example"
+        objectQuotingStrategy="LEGACY">
     <empty/>
 </changeSet>
 {% endhighlight %}
@@ -41,6 +43,7 @@ empty
 changeSet:
   id: empty-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - empty: {}
 
@@ -52,6 +55,7 @@ changeSet:
   "changeSet": {
     "id": "empty-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "empty": {
@@ -77,11 +81,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/execute_command.md
+++ b/documentation/changes/execute_command.md
@@ -15,13 +15,14 @@ title: Change executeCommand
 
 # Change: 'executeCommand'
 
-Executes a system command. Because this refactoring doesn't generate SQL like most, using LiquiBase commands such as migrateSQL may not work as expected. Therefore, if at all possible use refactorings that generate SQL.
+Executes a system command. Because this refactoring doesn't generate SQL like most, using Liquibase commands such as migrateSQL may not work as expected. Therefore, if at all possible use refactorings that generate SQL.
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>executable</td><td style='vertical-align: top'>Name of the executable to run</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>timeout</td><td style='vertical-align: top'>Timeout value for executable to run</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -32,8 +33,10 @@ Executes a system command. Because this refactoring doesn't generate SQL like mo
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="executeCommand-example">
-    <executeCommand executable="mysqldump"/>
+<changeSet author="liquibase-docs"
+        id="executeCommand-example"
+        objectQuotingStrategy="LEGACY">
+    <executeCommand executable="mysqldump" timeout="10s"/>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -42,9 +45,11 @@ Executes a system command. Because this refactoring doesn't generate SQL like mo
 changeSet:
   id: executeCommand-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - executeCommand:
       executable: mysqldump
+      timeout: 10s
 
 {% endhighlight %}
 </div>
@@ -54,10 +59,12 @@ changeSet:
   "changeSet": {
     "id": "executeCommand-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "executeCommand": {
-          "executable": "mysqldump"
+          "executable": "mysqldump",
+          "timeout": "10s"
         }
       }]
     
@@ -74,11 +81,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/insert.md
+++ b/documentation/changes/insert.md
@@ -41,7 +41,9 @@ Inserts data into an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="insert-example">
+<changeSet author="liquibase-docs"
+        id="insert-example"
+        objectQuotingStrategy="LEGACY">
     <insert catalogName="cat"
             dbms="h2, oracle"
             schemaName="public"
@@ -56,6 +58,7 @@ Inserts data into an existing table
 changeSet:
   id: insert-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - insert:
       catalogName: cat
@@ -75,6 +78,7 @@ changeSet:
   "changeSet": {
     "id": "insert-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "insert": {
@@ -114,11 +118,14 @@ INSERT INTO cat.person (address) VALUES (NULL);
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/load_data.md
+++ b/documentation/changes/load_data.md
@@ -15,25 +15,31 @@ title: Change loadData
 
 # Change: 'loadData'
 
-Loads data from a CSV file into an existing table. A value of NULL in a cell will be converted to a database NULL rather than the string 'NULL'
+Loads data from a CSV file into an existing table. A value of NULL in a cell will be converted to a database NULL rather than the string 'NULL'.
+Lines starting with # (hash) sign are treated as comments. You can change comment pattern by specifying 'commentLineStartsWith' property in loadData tag.To disable comments set 'commentLineStartsWith' to empty value'
 
-Date/Time values included in the CSV file should be in [ISO format](http://en.wikipedia.org/wiki/ISO_8601) in order to be parsed correctly by Liquibase. Liquibase will initially set the date format to be 'yyyy-MM-dd'T'HH:mm:ss' and then it checks for two special cases which will override the data format string.
+If the data type for a load column is set to NUMERIC, numbers are parsed in US locale (e.g. 123.45).
+Date/Time values included in the CSV file should be in ISO format http://en.wikipedia.org/wiki/ISO_8601 in order to be parsed correctly by Liquibase. Liquibase will initially set the date format to be 'yyyy-MM-dd'T'HH:mm:ss' and then it checks for two special cases which will override the data format string.
 
 If the string representing the date/time includes a '.', then the date format is changed to 'yyyy-MM-dd'T'HH:mm:ss.SSS'
 If the string representing the date/time includes a space, then the date format is changed to 'yyyy-MM-dd HH:mm:ss'
 Once the date format string is set, Liquibase will then call the SimpleDateFormat.parse() method attempting to parse the input string so that it can return a Date/Time. If problems occur, then a ParseException is thrown and the input string is treated as a String for the INSERT command to be generated.
+If UUID type is used UUID value is stored as string and NULL in cell is supported. Column config should be used in xml.
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
+<tr><td style='vertical-align: top'>commentLineStartsWith</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>encoding</td><td style='vertical-align: top'>Encoding of the CSV file (defaults to UTF-8)</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>file</td><td style='vertical-align: top'>CSV file to load</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>quotchar</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>relativeToChangelogFile</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>separator</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to insert data into</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>usePreparedStatements</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 ## Nested Properties ##
@@ -50,14 +56,19 @@ Once the date format string is set, Liquibase will then call the SimpleDateForma
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="loadData-example">
+<changeSet author="liquibase-docs"
+        id="loadData-example"
+        objectQuotingStrategy="LEGACY">
     <loadData catalogName="cat"
+            commentLineStartsWith="A String"
             encoding="UTF-8"
             file="com/example/users.csv"
-            quotchar="A String"
+            quotchar="'"
+            relativeToChangelogFile="true"
             schemaName="public"
-            separator="A String"
-            tableName="person">
+            separator=","
+            tableName="person"
+            usePreparedStatements="true">
         <column name="address" type="varchar(255)"/>
     </loadData>
 </changeSet>
@@ -68,6 +79,7 @@ Once the date format string is set, Liquibase will then call the SimpleDateForma
 changeSet:
   id: loadData-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - loadData:
       catalogName: cat
@@ -75,12 +87,15 @@ changeSet:
       - column:
           name: address
           type: varchar(255)
+      commentLineStartsWith: A String
       encoding: UTF-8
       file: com/example/users.csv
-      quotchar: A String
+      quotchar: ''''
+      relativeToChangelogFile: true
       schemaName: public
-      separator: A String
+      separator: ','
       tableName: person
+      usePreparedStatements: true
 
 {% endhighlight %}
 </div>
@@ -90,6 +105,7 @@ changeSet:
   "changeSet": {
     "id": "loadData-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "loadData": {
@@ -102,12 +118,15 @@ changeSet:
               }
             }]
           ,
+          "commentLineStartsWith": "A String",
           "encoding": "UTF-8",
           "file": "com/example/users.csv",
-          "quotchar": "A String",
+          "quotchar": "'",
+          "relativeToChangelogFile": true,
           "schemaName": "public",
-          "separator": "A String",
-          "tableName": "person"
+          "separator": ",",
+          "tableName": "person",
+          "usePreparedStatements": true
         }
       }]
     
@@ -119,40 +138,19 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (MySQL)
-
-{% highlight sql %}
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('1,
- Fred,
- 21');
-
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('2,
- Wilma,
- 22');
-
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('3,
- Barney,
- 42');
-
-
-{% endhighlight %}
-
 ## Database Support
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/load_update_data.md
+++ b/documentation/changes/load_update_data.md
@@ -24,13 +24,17 @@ A value of NULL in a cell will be converted to a database NULL rather than the s
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
+<tr><td style='vertical-align: top'>commentLineStartsWith</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>encoding</td><td style='vertical-align: top'>Encoding of the CSV file (defaults to UTF-8)</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>file</td><td style='vertical-align: top'>CSV file to load</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>onlyUpdate</td><td style='vertical-align: top'>If true, records with no matching database record should be ignored</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.3</td></tr>
 <tr><td style='vertical-align: top'>primaryKey</td><td style='vertical-align: top'>Comma delimited list of the columns for the primary key</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>quotchar</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>relativeToChangelogFile</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>separator</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table to insert or update data in</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>usePreparedStatements</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 ## Nested Properties ##
@@ -47,15 +51,21 @@ A value of NULL in a cell will be converted to a database NULL rather than the s
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="loadUpdateData-example">
+<changeSet author="liquibase-docs"
+        id="loadUpdateData-example"
+        objectQuotingStrategy="LEGACY">
     <loadUpdateData catalogName="cat"
+            commentLineStartsWith="A String"
             encoding="UTF-8"
             file="com/example/users.csv"
+            onlyUpdate="true"
             primaryKey="pk_id"
-            quotchar="A String"
+            quotchar="'"
+            relativeToChangelogFile="true"
             schemaName="public"
-            separator="A String"
-            tableName="person">
+            separator=","
+            tableName="person"
+            usePreparedStatements="true">
         <column name="address" type="varchar(255)"/>
     </loadUpdateData>
 </changeSet>
@@ -66,6 +76,7 @@ A value of NULL in a cell will be converted to a database NULL rather than the s
 changeSet:
   id: loadUpdateData-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - loadUpdateData:
       catalogName: cat
@@ -73,13 +84,17 @@ changeSet:
       - column:
           name: address
           type: varchar(255)
+      commentLineStartsWith: A String
       encoding: UTF-8
       file: com/example/users.csv
+      onlyUpdate: true
       primaryKey: pk_id
-      quotchar: A String
+      quotchar: ''''
+      relativeToChangelogFile: true
       schemaName: public
-      separator: A String
+      separator: ','
       tableName: person
+      usePreparedStatements: true
 
 {% endhighlight %}
 </div>
@@ -89,6 +104,7 @@ changeSet:
   "changeSet": {
     "id": "loadUpdateData-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "loadUpdateData": {
@@ -101,13 +117,17 @@ changeSet:
               }
             }]
           ,
+          "commentLineStartsWith": "A String",
           "encoding": "UTF-8",
           "file": "com/example/users.csv",
+          "onlyUpdate": true,
           "primaryKey": "pk_id",
-          "quotchar": "A String",
+          "quotchar": "'",
+          "relativeToChangelogFile": true,
           "schemaName": "public",
-          "separator": "A String",
-          "tableName": "person"
+          "separator": ",",
+          "tableName": "person",
+          "usePreparedStatements": true
         }
       }]
     
@@ -119,55 +139,19 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (MySQL)
-
-{% highlight sql %}
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('1,
- Fred,
- 21')
-ON DUPLICATE KEY UPDATE id,
- name,
- age = '1,
- Fred,
- 21'
-
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('2,
- Wilma,
- 22')
-ON DUPLICATE KEY UPDATE id,
- name,
- age = '2,
- Wilma,
- 22'
-
-INSERT INTO cat.person (`id,
- name,
- age`) VALUES ('3,
- Barney,
- 42')
-ON DUPLICATE KEY UPDATE id,
- name,
- age = '3,
- Barney,
- 42'
-
-
-{% endhighlight %}
-
 ## Database Support
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/merge_columns.md
+++ b/documentation/changes/merge_columns.md
@@ -39,7 +39,9 @@ Concatenates the values in two columns, joins them by with string, and stores th
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="mergeColumns-example">
+<changeSet author="liquibase-docs"
+        id="mergeColumns-example"
+        objectQuotingStrategy="LEGACY">
     <mergeColumns catalogName="cat"
             column1Name="first_name"
             column2Name="last_name"
@@ -56,6 +58,7 @@ Concatenates the values in two columns, joins them by with string, and stores th
 changeSet:
   id: mergeColumns-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - mergeColumns:
       catalogName: cat
@@ -75,6 +78,7 @@ changeSet:
   "changeSet": {
     "id": "mergeColumns-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "mergeColumns": {
@@ -117,12 +121,15 @@ ALTER TABLE public.person DROP COLUMN last_name;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
+<tr><td>DB2</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/output.md
+++ b/documentation/changes/output.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Change modifyDataType
+title: Change output
 ---
 
 <!-- ====================================================== -->
@@ -13,19 +13,16 @@ title: Change modifyDataType
   });
 </script>
 
-# Change: 'modifyDataType'
+# Change: 'output'
 
-Modify data type
+Logs a message and continues execution.
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
-<tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>newDataType</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>message</td><td style='vertical-align: top'>Message to output</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>target</td><td style='vertical-align: top'>Target for message. Possible values: STDOUT, STDERR, FATAL, WARN, INFO, DEBUG. Default value: STDERR</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -37,29 +34,22 @@ Modify data type
 <div id='tab-xml'>
 {% highlight xml %}
 <changeSet author="liquibase-docs"
-        id="modifyDataType-example"
+        id="output-example"
         objectQuotingStrategy="LEGACY">
-    <modifyDataType catalogName="cat"
-            columnName="id"
-            newDataType="int"
-            schemaName="public"
-            tableName="person"/>
+    <output target="STDERR">Make sure you feed the cat</output>
 </changeSet>
 {% endhighlight %}
 </div>
 <div id='tab-yaml'>
 {% highlight yaml %}
 changeSet:
-  id: modifyDataType-example
+  id: output-example
   author: liquibase-docs
   objectQuotingStrategy: LEGACY
   changes:
-  - modifyDataType:
-      catalogName: cat
-      columnName: id
-      newDataType: int
-      schemaName: public
-      tableName: person
+  - output:
+      message: Make sure you feed the cat
+      target: STDERR
 
 {% endhighlight %}
 </div>
@@ -67,17 +57,14 @@ changeSet:
 {% highlight json %}
 {
   "changeSet": {
-    "id": "modifyDataType-example",
+    "id": "output-example",
     "author": "liquibase-docs",
     "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
-        "modifyDataType": {
-          "catalogName": "cat",
-          "columnName": "id",
-          "newDataType": "int",
-          "schemaName": "public",
-          "tableName": "person"
+        "output": {
+          "message": "Make sure you feed the cat",
+          "target": "STDERR"
         }
       }]
     
@@ -92,8 +79,6 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person MODIFY id INT;
-
 
 {% endhighlight %}
 
@@ -101,7 +86,7 @@ ALTER TABLE cat.person MODIFY id INT;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
-<tr><td>DB2</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
@@ -114,7 +99,7 @@ ALTER TABLE cat.person MODIFY id INT;
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>SQLite</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Sybase</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/rename_column.md
+++ b/documentation/changes/rename_column.md
@@ -22,7 +22,7 @@ Renames an existing column
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Data type of the column</td><td style='vertical-align: top'>mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Data type of the column</td><td style='vertical-align: top'>mariadb, mysql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>newColumnName</td><td style='vertical-align: top'>Name to rename the column to</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>oldColumnName</td><td style='vertical-align: top'>Name of the existing column to rename</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>remarks</td><td style='vertical-align: top'>Remarks of the column</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
@@ -38,11 +38,13 @@ Renames an existing column
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="renameColumn-example">
+<changeSet author="liquibase-docs"
+        id="renameColumn-example"
+        objectQuotingStrategy="LEGACY">
     <renameColumn catalogName="cat"
             columnDataType="int"
-            newColumnName="id"
-            oldColumnName="id"
+            newColumnName="full_name"
+            oldColumnName="name"
             remarks="A String"
             schemaName="public"
             tableName="person"/>
@@ -54,12 +56,13 @@ Renames an existing column
 changeSet:
   id: renameColumn-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - renameColumn:
       catalogName: cat
       columnDataType: int
-      newColumnName: id
-      oldColumnName: id
+      newColumnName: full_name
+      oldColumnName: name
       remarks: A String
       schemaName: public
       tableName: person
@@ -72,13 +75,14 @@ changeSet:
   "changeSet": {
     "id": "renameColumn-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "renameColumn": {
           "catalogName": "cat",
           "columnDataType": "int",
-          "newColumnName": "id",
-          "oldColumnName": "id",
+          "newColumnName": "full_name",
+          "oldColumnName": "name",
           "remarks": "A String",
           "schemaName": "public",
           "tableName": "person"
@@ -96,7 +100,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person CHANGE id id INT COMMENT 'A String';
+ALTER TABLE cat.person CHANGE name full_name INT COMMENT 'A String';
 
 
 {% endhighlight %}
@@ -106,11 +110,14 @@ ALTER TABLE cat.person CHANGE id id INT COMMENT 'A String';
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/rename_sequence.md
+++ b/documentation/changes/rename_sequence.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Change dropNotNullConstraint
+title: Change renameSequence
 ---
 
 <!-- ====================================================== -->
@@ -13,19 +13,18 @@ title: Change dropNotNullConstraint
   });
 </script>
 
-# Change: 'dropNotNullConstraint'
+# Change: 'renameSequence'
 
-Makes a column nullable
+Renames an existing sequence
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnDataType</td><td style='vertical-align: top'>Current data type of the column</td><td style='vertical-align: top'>informix, mariadb, mysql, mssql</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column to drop the constraint from</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>newSequenceName</td><td style='vertical-align: top'>New name for the sequence</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>oldSequenceName</td><td style='vertical-align: top'>Name of the sequence to rename</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table containing that the column to drop the constraint from</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -37,29 +36,27 @@ Makes a column nullable
 <div id='tab-xml'>
 {% highlight xml %}
 <changeSet author="liquibase-docs"
-        id="dropNotNullConstraint-example"
+        id="renameSequence-example"
         objectQuotingStrategy="LEGACY">
-    <dropNotNullConstraint catalogName="cat"
-            columnDataType="int"
-            columnName="id"
-            schemaName="public"
-            tableName="person"/>
+    <renameSequence catalogName="cat"
+            newSequenceName="seq_id"
+            oldSequenceName="seq_id"
+            schemaName="public"/>
 </changeSet>
 {% endhighlight %}
 </div>
 <div id='tab-yaml'>
 {% highlight yaml %}
 changeSet:
-  id: dropNotNullConstraint-example
+  id: renameSequence-example
   author: liquibase-docs
   objectQuotingStrategy: LEGACY
   changes:
-  - dropNotNullConstraint:
+  - renameSequence:
       catalogName: cat
-      columnDataType: int
-      columnName: id
+      newSequenceName: seq_id
+      oldSequenceName: seq_id
       schemaName: public
-      tableName: person
 
 {% endhighlight %}
 </div>
@@ -67,17 +64,16 @@ changeSet:
 {% highlight json %}
 {
   "changeSet": {
-    "id": "dropNotNullConstraint-example",
+    "id": "renameSequence-example",
     "author": "liquibase-docs",
     "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
-        "dropNotNullConstraint": {
+        "renameSequence": {
           "catalogName": "cat",
-          "columnDataType": "int",
-          "columnName": "id",
-          "schemaName": "public",
-          "tableName": "person"
+          "newSequenceName": "seq_id",
+          "oldSequenceName": "seq_id",
+          "schemaName": "public"
         }
       }]
     
@@ -89,10 +85,11 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (MySQL)
+## SQL Generated From Above Sample (SQL Server)
 
 {% highlight sql %}
-ALTER TABLE cat.person MODIFY id INT NULL;
+SP_RENAME seq_id ,
+seq_id;
 
 
 {% endhighlight %}
@@ -102,19 +99,19 @@ ALTER TABLE cat.person MODIFY id INT NULL;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
-<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td><b>Yes</b></td></tr>
-<tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
-<tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>H2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>HyperSQL</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>Informix</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>MySQL</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>SQL Server</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td><b>Yes</b></td></tr>
-<tr><td>Sybase</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>Sybase</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 </table>

--- a/documentation/changes/rename_table.md
+++ b/documentation/changes/rename_table.md
@@ -35,9 +35,11 @@ Renames an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="renameTable-example">
+<changeSet author="liquibase-docs"
+        id="renameTable-example"
+        objectQuotingStrategy="LEGACY">
     <renameTable catalogName="cat"
-            newTableName="person"
+            newTableName="employee"
             oldTableName="person"
             schemaName="public"/>
 </changeSet>
@@ -48,10 +50,11 @@ Renames an existing table
 changeSet:
   id: renameTable-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - renameTable:
       catalogName: cat
-      newTableName: person
+      newTableName: employee
       oldTableName: person
       schemaName: public
 
@@ -63,11 +66,12 @@ changeSet:
   "changeSet": {
     "id": "renameTable-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "renameTable": {
           "catalogName": "cat",
-          "newTableName": "person",
+          "newTableName": "employee",
           "oldTableName": "person",
           "schemaName": "public"
         }
@@ -84,7 +88,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person RENAME cat.person;
+ALTER TABLE cat.person RENAME cat.employee;
 
 
 {% endhighlight %}
@@ -94,11 +98,14 @@ ALTER TABLE cat.person RENAME cat.person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/rename_view.md
+++ b/documentation/changes/rename_view.md
@@ -24,7 +24,7 @@ Renames an existing view
 <tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
 <tr><td style='vertical-align: top'>newViewName</td><td style='vertical-align: top'>Name to rename the view to</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>oldViewName</td><td style='vertical-align: top'>Name of the view to rename</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>sybase, mssql, postgresql, sqlite, mysql</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>mariadb, sybase, sqlite, postgresql, ingres, mysql, mssql</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -35,7 +35,9 @@ Renames an existing view
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="renameView-example">
+<changeSet author="liquibase-docs"
+        id="renameView-example"
+        objectQuotingStrategy="LEGACY">
     <renameView catalogName="cat"
             newViewName="v_person"
             oldViewName="v_person"
@@ -48,6 +50,7 @@ Renames an existing view
 changeSet:
   id: renameView-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - renameView:
       catalogName: cat
@@ -63,6 +66,7 @@ changeSet:
   "changeSet": {
     "id": "renameView-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "renameView": {
@@ -94,11 +98,14 @@ RENAME TABLE cat.v_person TO cat.v_person;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td>Not Supported</td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td>Not Supported</td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/set_column_remarks.md
+++ b/documentation/changes/set_column_remarks.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Change modifyDataType
+title: Change setColumnRemarks
 ---
 
 <!-- ====================================================== -->
@@ -13,17 +13,17 @@ title: Change modifyDataType
   });
 </script>
 
-# Change: 'modifyDataType'
+# Change: 'setColumnRemarks'
 
-Modify data type
+Set remarks on a column
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
-<tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
+<tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>newDataType</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>remarks</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
@@ -37,11 +37,11 @@ Modify data type
 <div id='tab-xml'>
 {% highlight xml %}
 <changeSet author="liquibase-docs"
-        id="modifyDataType-example"
+        id="setColumnRemarks-example"
         objectQuotingStrategy="LEGACY">
-    <modifyDataType catalogName="cat"
+    <setColumnRemarks catalogName="cat"
             columnName="id"
-            newDataType="int"
+            remarks="A String"
             schemaName="public"
             tableName="person"/>
 </changeSet>
@@ -50,14 +50,14 @@ Modify data type
 <div id='tab-yaml'>
 {% highlight yaml %}
 changeSet:
-  id: modifyDataType-example
+  id: setColumnRemarks-example
   author: liquibase-docs
   objectQuotingStrategy: LEGACY
   changes:
-  - modifyDataType:
+  - setColumnRemarks:
       catalogName: cat
       columnName: id
-      newDataType: int
+      remarks: A String
       schemaName: public
       tableName: person
 
@@ -67,15 +67,15 @@ changeSet:
 {% highlight json %}
 {
   "changeSet": {
-    "id": "modifyDataType-example",
+    "id": "setColumnRemarks-example",
     "author": "liquibase-docs",
     "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
-        "modifyDataType": {
+        "setColumnRemarks": {
           "catalogName": "cat",
           "columnName": "id",
-          "newDataType": "int",
+          "remarks": "A String",
           "schemaName": "public",
           "tableName": "person"
         }
@@ -92,7 +92,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person MODIFY id INT;
+ALTER TABLE cat.person COMMENT = 'A String';
 
 
 {% endhighlight %}
@@ -101,20 +101,20 @@ ALTER TABLE cat.person MODIFY id INT;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
-<tr><td>DB2</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Firebird</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>HyperSQL</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Informix</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
-<tr><td>Sybase</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Sybase</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/set_table_remarks.md
+++ b/documentation/changes/set_table_remarks.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Change modifyDataType
+title: Change setTableRemarks
 ---
 
 <!-- ====================================================== -->
@@ -13,17 +13,16 @@ title: Change modifyDataType
   });
 </script>
 
-# Change: 'modifyDataType'
+# Change: 'setTableRemarks'
 
-Modify data type
+Set remarks on a table
 
 ## Available Attributes ##
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
-<tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'>3.0</td></tr>
-<tr><td style='vertical-align: top'>columnName</td><td style='vertical-align: top'>Name of the column</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
-<tr><td style='vertical-align: top'>newDataType</td><td style='vertical-align: top'></td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>catalogName</td><td style='vertical-align: top'>Name of the catalog</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>remarks</td><td style='vertical-align: top'></td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>schemaName</td><td style='vertical-align: top'>Name of the schema</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 <tr><td style='vertical-align: top'>tableName</td><td style='vertical-align: top'>Name of the table</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
@@ -37,11 +36,10 @@ Modify data type
 <div id='tab-xml'>
 {% highlight xml %}
 <changeSet author="liquibase-docs"
-        id="modifyDataType-example"
+        id="setTableRemarks-example"
         objectQuotingStrategy="LEGACY">
-    <modifyDataType catalogName="cat"
-            columnName="id"
-            newDataType="int"
+    <setTableRemarks catalogName="cat"
+            remarks="A String"
             schemaName="public"
             tableName="person"/>
 </changeSet>
@@ -50,14 +48,13 @@ Modify data type
 <div id='tab-yaml'>
 {% highlight yaml %}
 changeSet:
-  id: modifyDataType-example
+  id: setTableRemarks-example
   author: liquibase-docs
   objectQuotingStrategy: LEGACY
   changes:
-  - modifyDataType:
+  - setTableRemarks:
       catalogName: cat
-      columnName: id
-      newDataType: int
+      remarks: A String
       schemaName: public
       tableName: person
 
@@ -67,15 +64,14 @@ changeSet:
 {% highlight json %}
 {
   "changeSet": {
-    "id": "modifyDataType-example",
+    "id": "setTableRemarks-example",
     "author": "liquibase-docs",
     "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
-        "modifyDataType": {
+        "setTableRemarks": {
           "catalogName": "cat",
-          "columnName": "id",
-          "newDataType": "int",
+          "remarks": "A String",
           "schemaName": "public",
           "tableName": "person"
         }
@@ -92,7 +88,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-ALTER TABLE cat.person MODIFY id INT;
+ALTER TABLE cat.person COMMENT = 'A String';
 
 
 {% endhighlight %}
@@ -101,20 +97,20 @@ ALTER TABLE cat.person MODIFY id INT;
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
-<tr><td>DB2</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Derby</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Firebird</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
-<tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>HyperSQL</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>INGRES</td><td>Not Supported</td><td>No</td></tr>
+<tr><td>Informix</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQL Server</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>SQLite</td><td>Not Supported</td><td>No</td></tr>
-<tr><td>Sybase</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>Sybase</td><td>Not Supported</td><td>No</td></tr>
 <tr><td>Sybase Anywhere</td><td><b>Supported</b></td><td>No</td></tr>
 </table>

--- a/documentation/changes/sql.md
+++ b/documentation/changes/sql.md
@@ -19,7 +19,7 @@ The 'sql' tag allows you to specify whatever sql you want. It is useful for comp
 
 The createProcedure refactoring is the best way to create stored procedures.
 
-The 'sql' tag can also support multiline statements in the same file. Statements can either be split using a ; at the end of the last line of the SQL or a go on its own on the line between the statements can be used. Multiline SQL statements are also supported and only a ; or go statement will finish a statement, a new line is not enough. Files containing a single statement do not need to use a ; or go.
+The 'sql' tag can also support multiline statements in the same file. Statements can either be split using a ; at the end of the last line of the SQL or a go on its own on the line between the statements can be used.Multiline SQL statements are also supported and only a ; or go statement will finish a statement, a new line is not enough. Files containing a single statement do not need to use a ; or go.
 
 The sql change can also contain comments of either of the following formats:
 
@@ -47,15 +47,13 @@ Note: By default it will attempt to split statements on a ';' or 'go' at the end
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="sql-example">
+<changeSet author="liquibase-docs"
+        id="sql-example"
+        objectQuotingStrategy="LEGACY">
     <sql dbms="h2, oracle"
             endDelimiter="\nGO"
             splitStatements="true"
-            stripComments="true"
-    >
-        insert into person (name) values ('Bob')
-    </sql>
-    <comment>What about Bob?</comment>
+            stripComments="true">insert into person (name) values ('Bob')</sql>
 </changeSet>
 {% endhighlight %}
 </div>
@@ -64,6 +62,7 @@ Note: By default it will attempt to split statements on a ';' or 'go' at the end
 changeSet:
   id: sql-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - sql:
       comment: What about Bob?
@@ -81,6 +80,7 @@ changeSet:
   "changeSet": {
     "id": "sql-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "sql": {
@@ -115,11 +115,14 @@ GO
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/sql_file.md
+++ b/documentation/changes/sql_file.md
@@ -15,13 +15,13 @@ title: Change sqlFile
 
 # Change: 'sqlFile'
 
-The 'sqlFile' tag allows you to specify any sql statements and have it stored external in a file. It is useful for complex changes that are not supported through LiquiBase's automated refactoring tags such as stored procedures.
+The 'sqlFile' tag allows you to specify any sql statements and have it stored external in a file. It is useful for complex changes that are not supported through Liquibase's automated refactoring tags such as stored procedures.
 
 The sqlFile refactoring finds the file by searching in the following order:
 
-The file is searched for in the classpath. This can be manually set and by default the liquibase startup script adds the current directory when run.
+The file is searched for in the classpath. This can be manually set and by default the Liquibase startup script adds the current directory when run.
 The file is searched for using the file attribute as a file name. This allows absolute paths to be used or relative paths to the working directory to be used.
-The 'sqlFile' tag can also support multiline statements in the same file. Statements can either be split using a ; at the end of the last line of the SQL or a go on its own on the line between the statements can be used. Multiline SQL statements are also supported and only a ; or go statement will finish a statement, a new line is not enough. Files containing a single statement do not need to use a ; or go.
+The 'sqlFile' tag can also support multiline statements in the same file. Statements can either be split using a ; at the end of the last line of the SQL or a go on its own on the line between the statements can be used.Multiline SQL statements are also supported and only a ; or go statement will finish a statement, a new line is not enough. Files containing a single statement do not need to use a ; or go.
 
 The sql file can also contain comments of either of the following formats:
 
@@ -49,9 +49,11 @@ A single line comment starting with &lt;space&gt;--&lt;space&gt; and finishing a
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="sqlFile-example">
+<changeSet author="liquibase-docs"
+        id="sqlFile-example"
+        objectQuotingStrategy="LEGACY">
     <sqlFile dbms="h2, oracle"
-            encoding="utf8"
+            encoding="UTF-8"
             endDelimiter="\nGO"
             path="my/path/file.sql"
             relativeToChangelogFile="true"
@@ -65,10 +67,11 @@ A single line comment starting with &lt;space&gt;--&lt;space&gt; and finishing a
 changeSet:
   id: sqlFile-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - sqlFile:
       dbms: h2, oracle
-      encoding: utf8
+      encoding: UTF-8
       endDelimiter: \nGO
       path: my/path/file.sql
       relativeToChangelogFile: true
@@ -83,11 +86,12 @@ changeSet:
   "changeSet": {
     "id": "sqlFile-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "sqlFile": {
           "dbms": "h2, oracle",
-          "encoding": "utf8",
+          "encoding": "UTF-8",
           "endDelimiter": "\\nGO",
           "path": "my/path/file.sql",
           "relativeToChangelogFile": true,
@@ -104,22 +108,19 @@ changeSet:
 </div>
 
 
-## SQL Generated From Above Sample (MySQL)
-
-{% highlight sql %}
-
-{% endhighlight %}
-
 ## Database Support
 
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/stop.md
+++ b/documentation/changes/stop.md
@@ -32,7 +32,9 @@ Stops Liquibase execution with a message. Mainly useful for debugging and steppi
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="stop-example">
+<changeSet author="liquibase-docs"
+        id="stop-example"
+        objectQuotingStrategy="LEGACY">
     <stop message="What just happened???"/>
 </changeSet>
 {% endhighlight %}
@@ -42,6 +44,7 @@ Stops Liquibase execution with a message. Mainly useful for debugging and steppi
 changeSet:
   id: stop-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - stop:
       message: What just happened???
@@ -54,6 +57,7 @@ changeSet:
   "changeSet": {
     "id": "stop-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "stop": {
@@ -74,11 +78,14 @@ changeSet:
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>

--- a/documentation/changes/tag_database.md
+++ b/documentation/changes/tag_database.md
@@ -21,7 +21,7 @@ Applies a tag to the database for future rollback
 
 <table>
 <tr><th>Name</th><th>Description</th><th>Required&nbsp;For</th><th>Supports</th><th>Since</th></tr>
-<tr><td style='vertical-align: top'>tag</td><td style='vertical-align: top'>Tag to apply</td><td style='vertical-align: top'>all</td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
+<tr><td style='vertical-align: top'>tag</td><td style='vertical-align: top'>Tag to apply</td><td style='vertical-align: top'></td><td style='vertical-align:top'>all</td><td style='vertical-align: top'></td></tr>
 </table>
 
 <div id='changelog-tabs'>
@@ -32,7 +32,9 @@ Applies a tag to the database for future rollback
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="tagDatabase-example">
+<changeSet author="liquibase-docs"
+        id="tagDatabase-example"
+        objectQuotingStrategy="LEGACY">
     <tagDatabase tag="version_1.3"/>
 </changeSet>
 {% endhighlight %}
@@ -42,6 +44,7 @@ Applies a tag to the database for future rollback
 changeSet:
   id: tagDatabase-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - tagDatabase:
       tag: version_1.3
@@ -54,6 +57,7 @@ changeSet:
   "changeSet": {
     "id": "tagDatabase-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "tagDatabase": {
@@ -72,8 +76,6 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-UPDATE DATABASECHANGELOG SET TAG = 'version_1.3' WHERE DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM (SELECT DATEEXECUTED FROM DATABASECHANGELOG) AS X);
-
 
 {% endhighlight %}
 
@@ -82,11 +84,14 @@ UPDATE DATABASECHANGELOG SET TAG = 'version_1.3' WHERE DATEEXECUTED = (SELECT MA
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td><b>Yes</b></td></tr>

--- a/documentation/changes/update.md
+++ b/documentation/changes/update.md
@@ -41,12 +41,14 @@ Updates data in an existing table
   </ul>
 <div id='tab-xml'>
 {% highlight xml %}
-<changeSet author="liquibase-docs" id="update-example">
+<changeSet author="liquibase-docs"
+        id="update-example"
+        objectQuotingStrategy="LEGACY">
     <update catalogName="cat"
             schemaName="public"
             tableName="person">
         <column name="address" type="varchar(255)"/>
-        <where>A String</where>
+        <where>name='Bob'</where>
     </update>
 </changeSet>
 {% endhighlight %}
@@ -56,6 +58,7 @@ Updates data in an existing table
 changeSet:
   id: update-example
   author: liquibase-docs
+  objectQuotingStrategy: LEGACY
   changes:
   - update:
       catalogName: cat
@@ -65,7 +68,7 @@ changeSet:
           type: varchar(255)
       schemaName: public
       tableName: person
-      where: A String
+      where: name='Bob'
 
 {% endhighlight %}
 </div>
@@ -75,6 +78,7 @@ changeSet:
   "changeSet": {
     "id": "update-example",
     "author": "liquibase-docs",
+    "objectQuotingStrategy": "LEGACY",
     "changes": [
       {
         "update": {
@@ -89,7 +93,7 @@ changeSet:
           ,
           "schemaName": "public",
           "tableName": "person",
-          "where": "A String"
+          "where": "name='Bob'"
         }
       }]
     
@@ -104,7 +108,7 @@ changeSet:
 ## SQL Generated From Above Sample (MySQL)
 
 {% highlight sql %}
-UPDATE cat.person SET address = NULL WHERE A String;
+UPDATE cat.person SET address = NULL WHERE name='Bob';
 
 
 {% endhighlight %}
@@ -114,11 +118,14 @@ UPDATE cat.person SET address = NULL WHERE A String;
 <table style='border:1;'>
 <tr><th>Database</th><th>Notes</th><th>Auto Rollback</th></tr>
 <tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>DB2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Derby</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Firebird</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>H2</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>HyperSQL</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>INGRES</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Informix</td><td><b>Supported</b></td><td>No</td></tr>
+<tr><td>MariaDB</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>MySQL</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>Oracle</td><td><b>Supported</b></td><td>No</td></tr>
 <tr><td>PostgreSQL</td><td><b>Supported</b></td><td>No</td></tr>


### PR DESCRIPTION
@r2datical @nvoxland 
Regenerated the `/documentation/changes` using the ChangeDocGenerator. The ChangeDocGenerator removes the Pro section from `_includes/subnav_documentation_changes.md` so I had to un-staged those changes before pushing the updates.

If there are any concerns with these changes, then I suggest having someone with committer access run the generator on a clean branch by executing `gradlew generateChangesDoc -PliquibaseVersion=3.8.0` from a command line in the project base directory.
