### PR TITLE
Remove plug-in version from the declaration

### DIFF
--- a/documentation/maven/index.md
+++ b/documentation/maven/index.md
@@ -109,7 +109,6 @@ The following is a sample configuration for the Liquibase Maven plugin, version 
 		<plugin>
 		   <groupId>org.liquibase</groupId>
 		   <artifactId>liquibase-maven-plugin</artifactId>
-		   <version>3.0.5</version>
 		   <configuration>                  
 			  <propertyFile>src/main/resources/liquibase/liquibase.properties</propertyFile>
 		   </configuration>                


### PR DESCRIPTION
Version 3.0.5 is old and broken, it should not be advertised.

## What I Did

I tried running `liquibase:releaseLocks` in version 3.0.5 (as advertised) on a PostgreSQL database.
I got an error saying that the column "LOCKED" is not present.  Which is correct because the database uses lower case by default.
Removing the version declaration did the trick for me.

## How To Test It

In `liquibase.settings`:
>     driver=org.postgresql.Driver

In pom:
>					<groupId>org.liquibase</groupId>
>					<artifactId>liquibase-maven-plugin</artifactId>
>					<version>3.0.5</version>

      mvn liquibase:releaseLocks

## Picture of a Cute Animal (Not Required But Recommended for Sanity Purposes)

```
              ,,))))))));,
           __)))))))))))))),
\|/       -\(((((''''((((((((.
-*-==//////((''  .     `)))))),
/|\      ))| o    ;-.    '(((((                                  ,(,
         ( `|    /  )    ;))))'                               ,_))^;(~
            |   |   |   ,))((((_     _____------~~~-.        %,;(;(>';'~
            o_);   ;    )))(((` ~---~  `::           \      %%~~)(v;(`('~
                  ;    ''''````         `:       `:::|\,__,%%    );`'; ~
                 |   _                )     /      `:|`----'     `-'
           ______/\/~    |                 /        /
         /~;;.____/;;'  /          ___--,-(   `;;;/
        / //  _;______;'------~~~~~    /;;/\    /
       //  | |                        / ;   \;;,\
      (<_  | ;                      /',/-----'  _>
       \_| ||_                     //~;~~~~~~~~~
           `\_|                   (,~~  -Tua Xiong
                                   \~\
                                    ~~
```