### PR TITLE
[LOW-3] - Add Hotjar tracking to the Quick Start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,33 @@ Once Jekyll is installed, just navigate to this repo's directory, and run `jekyl
 If you're using a MarkDown editor with a "live preview" feature, be aware that it's unlikely to support Liquid's syntax highlighting tags, such as "{% highlight xml %}".
 
 ## Project Setup
-### Requirements
+### Requirements (Bundler)
 * [Ruby](https://ruby-doc.org/)
   * _OR_ [RVM](https://rvm.io/rvm/install)
 * [Bundler](https://bundler.io/)
 
+### Requirements (Docker)
+Or if you'd prefer to run everything through a docker container:
+* [Docker](https://www.docker.com/)
+
 ### Steps
-#### Install
+#### Bundler
+##### Install
 Once all requirements are met, you can install everything with:
 ```bash
 bundle install
 ```
 
-#### Local Dev Server
+##### Local Dev Server
 ```bash
 bundle exec jekyll serve 
 ```
 _Or_
 ```bash
 bundle exec jekyll serve -l
+```
+
+#### Docker
+```bash
+./scripts/docker-dev.sh
 ```

--- a/_includes/tracking-codes/hotjar.tracking-code.html
+++ b/_includes/tracking-codes/hotjar.tracking-code.html
@@ -1,0 +1,11 @@
+<!-- Hotjar Tracking Code for www.liquibase.org -->
+<script>
+  (function(h,o,t,j,a,r){
+      h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+      h._hjSettings={hjid:1455286,hjsv:6};
+      a=o.getElementsByTagName('head')[0];
+      r=o.createElement('script');r.async=1;
+      r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+      a.appendChild(r);
+  })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>

--- a/index.md
+++ b/index.md
@@ -109,14 +109,4 @@ extraStyleSheets:
     <a href="http://datical.com/">Datical</a> | <a href="https://atlassian.com/">Atlassian</a> | <a href="https://www.zoho.com/">Zoho</a> | <a href="https://www.yourkit.com/">YourKit</a>
 </p>
 
-<!-- Hotjar Tracking Code for www.liquibase.org -->
-<script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:1455286,hjsv:6};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+{% include tracking-codes/hotjar.tracking-code.html %}

--- a/quickstart.md
+++ b/quickstart.md
@@ -169,3 +169,5 @@ changeLogFile: myChangeLog.xml{% endhighlight bash %}
 <h3 style="display:flex; justify-content:center; text-align:center"><a class="cta" href="/quickstart/quickstart_lb.html">Start with Liquibase XML Changelogs</a></h3>
 
 </div>
+
+{% include tracking-codes/hotjar.tracking-code.html %}

--- a/scripts/docker-dev.sh
+++ b/scripts/docker-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+JEKYLL_VERSION=$(sed -E -n 's/^.*gem "jekyll", "[<>=~]{1,2} (.*)".*$/\1/p' ./Gemfile)
+docker run --volume="$PWD:/srv/jekyll" -p 3000:4000 -it jekyll/jekyll:$JEKYLL_VERSION jekyll serve --watch --drafts


### PR DESCRIPTION
## What I Did
* Moved hotjar to an include
* Included it where appropriate
* Added instructions for running development server via docker
* added a `./scripts/docker-dev.sh` to scrape Jekyll version from `./Gemfile` and run in watch mode.

## How To Test It
Tracking code should hit on both pages now.

## Picture of a Cute Animal (Not Required But Recommended for Sanity Purposes)