### PR TITLE
Fixing download link

### DIFF
--- a/documentation/installation-linux-unix-mac.md
+++ b/documentation/installation-linux-unix-mac.md
@@ -6,7 +6,7 @@ title: Installing Liquibase Command Line Tool for Linux/Unix/Mac
 
 # Installing Liquibase Command Line for Linux/Unix/Mac #
 
-Once you have downloaded the [Liquibase-Version#-bin.tar.gz file](https://www.download.liquibase.org/download), create a local directory on your computer (**Example:** `/usr/apps/Liquibase-3.8.0-bin`), then add the directory to your PATH.
+Once you have downloaded the [Liquibase-Version#-bin.tar.gz file](https://download.liquibase.org/download), create a local directory on your computer (**Example:** `/usr/apps/Liquibase-3.8.0-bin`), then add the directory to your PATH.
 To add the directory to your PATH:
 1. Open the Terminal or Linux Command Line.
 2. Run the following command: `export PATH=$PATH:/usr/apps/Liquibase-3.8.0-bin`


### PR DESCRIPTION
Currently clicking download link on this page: http://www.liquibase.org/documentation/installation-linux-unix-mac.html
... takes to www.download.liquibase.org, which doesn't exist and you get an error.

## What I Did
removed "www." to fix the link
## How To Test It
Click on download link near the top of the page and see it opening the download page.