### PR TITLE
Low-16, Removing links in left nav to pages that no longer exist.

### DIFF
--- a/_includes/subnav_documentation_sdk.md
+++ b/_includes/subnav_documentation_sdk.md
@@ -1,4 +1,2 @@
 <li><a href="/documentation/sdk/index.html"><span>SDK Home</span></a></li>
 <li><a href="/documentation/sdk/workspace.html"><span>Workspace</span></a></li>
-<li><a href="/documentation/sdk/vagrant.html"><span>Vagrant</span></a></li>
-<li><a href="/documentation/sdk/watch.html"><span>Watch</span></a></li>


### PR DESCRIPTION
## What I Did - Updated left nav to reflect existing pages. Two of the pages in the nav are no longer existing. Removed the link for Ticket Low-16

## How To Test It - View page.
