### PR TITLE
PD-79 extract common components and reduce duplication

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,64 +1,17 @@
 ---
 layout: base
 ---
+  {% include components/announcement.html %}
+
 <div class="container">
   <div class="span-24">
     <a class="logo" href="/index.html"></a>
 
   {% include components/search/gcse-search.html %}
-   
-
-  <div class="span-24" id="menu">
-    <div class="span-4">
-      <li>
-        <a href="http://download.liquibase.org">
-          <span>Download</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3">
-      <li>
-        <a href="/quickstart.html">
-          <span>Getting Started</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3">
-      <li>
-        <a href="/documentation/index.html">
-          <span>Documentation</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3">
-      <li>
-        <a href="/community/index.html">
-          <span>Community</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3">
-      <li>
-        <a href="/extensions/index.html">
-          <span>Extensions</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3">
-      <li>
-        <a href="http:///www.liquibase.org/blog">
-          <span>Blog</span>
-        </a>
-      </li>
-    </div>
-    <div class="span-3 last">
-      <li>
-        <a href="http://www.datical.com/liquibase/" onclick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false" target="_blank">
-          <span>Support&nbsp;and&nbsp;Training</span>
-        </a>
-      </li>
-    </div>
+  
   </div>
+
+  {% include components/top-nav.html %}
 
   <div class="span-24 last">
     <h1>404 Error: Unknown Page</h1>
@@ -74,8 +27,6 @@ layout: base
         <a href="/community/index.html">Links to forums, issue tracker, etc.</a>?</li>
     </ul>
 
-    or would like to just
-    <a href="/index.html">start from the beginning</a>
-    again.
+    or would you like to just <a href="/index.html">start from the beginning</a> again?
   </div>
 </div>

--- a/_includes/components/announcement.html
+++ b/_includes/components/announcement.html
@@ -1,0 +1,4 @@
+<div style="width: 100%; line-height: 24px; padding: 10px; vertical-align: top; display: block;
+    background-color: #416692; text-align: center; color: #ffffff; font-size: 16px; font-weight: bold; margin: 0 auto;">
+    <a style="color: #ffffff; text-decoration: none;" href="https://download.liquibase.org">Liquibase® version 3.8.1 is now available! Get it for free.</a>
+</div>

--- a/_includes/components/top-nav.html
+++ b/_includes/components/top-nav.html
@@ -1,0 +1,26 @@
+<div id="menu" class="span-24">
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="https://download.liquibase.org"><span>Download</span></a></li>
+    </div>
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="https://support.liquibase.org"><span>Support</span></a></li>
+    </div>
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="{{ pageRoot }}/quickstart.html"><span>Getting Started</span></a></li>
+    </div>
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="{{ pageRoot }}/documentation/index.html"><span>Documentation</span></a></li>
+    </div>
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="{{ pageRoot }}/community/index.html"><span>Community</span></a></li>
+    </div>
+    <div class="span-3" style="margin-top: 20px">
+        <li><a href="{{ pageRoot }}/extensions/index.html"><span>Extensions</span></a></li>
+    </div>
+    <div class="span-3 last" style="margin-top: 20px">
+        <li><a href="https://www.datical.com/liquibase/" target="_blank"
+               onClick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false"><span>
+            <font color="DarkOrange"><strong>Datical</strong></font>
+          </span></a></li>
+    </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,9 +4,7 @@ title: Liquibase News
 subnav: subnav_blog.md
 ---
 
-<div
-  style="width: 100%; line-height: 24px; padding: 10px; vertical-align: top; display: block; background-color: #416692; text-align: center; color: #ffffff; font-size: 16px; font-weight: bold; margin: 0 auto;">
-  <a style="color: #ffffff; text-decoration: none;" href="https://download.liquibase.org">Liquibase® version 3.8.1 is now available! Get it for free.</a></div>
+  {% include components/announcement.html %}
 
 <div class="container">
   <div class="span-24">
@@ -15,38 +13,7 @@ subnav: subnav_blog.md
     {% include components/search/gcse-search.html %}
   </div>
 
-  <div id="menu" class="span-24">
-    <!-- <div class="span-4" style="margin-top: 20px">
-                  <li><a href="https://download.liquibase.org"><span>Download</span></a></li>
-              </div> -->
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="https://download.liquibase.org"><span>Download</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="https://support.liquibase.org"><span>Support</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/quickstart.html"><span>Getting Started</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/documentation/index.html"><span>Documentation</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/community/index.html"><span>Community</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/extensions/index.html"><span>Extensions</span></a></li>
-    </div>
-    <!-- <div class="span-3" style="margin-top: 20px">
-                  <li><a href="{{ pageRoot }}/development/index.html"><span>Dev</span></a></li>
-              </div> -->
-    <div class="span-3 last" style="margin-top: 20px">
-      <li><a href="https://www.datical.com/liquibase/" target="_blank"
-          onClick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false"><span>
-            <font color="DarkOrange"><strong>Datical</strong></font>
-          </span></a></li>
-    </div>
-  </div>
+  {% include components/top-nav.html %}
 
   <div class="span-6 border">
     <ul id="leftnav">

--- a/_layouts/side-search.html
+++ b/_layouts/side-search.html
@@ -17,38 +17,7 @@ subnav: subnav_blog.md
     </div>
   </div>
 
-  <div id="menu" class="span-24">
-    <!-- <div class="span-4" style="margin-top: 20px">
-                  <li><a href="https://download.liquibase.org"><span>Download</span></a></li>
-              </div> -->
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="https://download.liquibase.org"><span>Download</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="https://support.liquibase.org"><span>Support</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/quickstart.html"><span>Getting Started</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/documentation/index.html"><span>Documentation</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/community/index.html"><span>Community</span></a></li>
-    </div>
-    <div class="span-3" style="margin-top: 20px">
-      <li><a href="{{ pageRoot }}/extensions/index.html"><span>Extensions</span></a></li>
-    </div>
-    <!-- <div class="span-3" style="margin-top: 20px">
-                  <li><a href="{{ pageRoot }}/development/index.html"><span>Dev</span></a></li>
-              </div> -->
-    <div class="span-3 last" style="margin-top: 20px">
-      <li><a href="https://www.datical.com/liquibase/" target="_blank"
-          onClick="trackOutboundLink(this, 'Datical', 'Liquibase RFI'); return false"><span>
-            <font color="DarkOrange"><strong>Datical</strong></font>
-          </span></a></li>
-    </div>
-  </div>
+  {% include components/top-nav.html %}
 
   <div class="span-6 border">
     <ul id="leftnav">


### PR DESCRIPTION
## What I Did
* extracted the top 'announcement' div into a component
* used that component in the default layout and in the 404 page
* extracted the top nav menu into a component
* used that component in the default layout, the side-search layout, and the 404 page

## How To Test It
Everything should still look the same, except the 404 page should more closely match the rest of the site. 