### PR TITLE
Replace pre HTML tag with code to display inline

### DIFF
--- a/documentation/changelog_parameters.md
+++ b/documentation/changelog_parameters.md
@@ -63,7 +63,7 @@ Defines a parameter for the changelog. Given a list of contexts and/or databases
 <tr><td>context</td><td>Contexts given as comma separated list.  </td></tr>
 <tr><td>dbms</td><td>The type of a database which that changeSet is to be used for. When the migration step is running, it checks the database type against this 
   attribute. Valid database type names are listed on the <a href="../databases.html">supported databases page</a>. It is possible to list multiple databases separated by commas. 
-  You can also specify that a changeset is <b>NOT</b> applicable to a particular database type by prefixing with <pre>!</pre>. The keywords <pre>all</pre> and <pre>none</pre> are 
+  You can also specify that a changeset is <b>NOT</b> applicable to a particular database type by prefixing with <code>!</code>. The keywords <code>all</code> and <code>none</code> are 
   also available.</td></tr>
 <tr><td>global</td><td>Defines whether the property is global or limited to a databaseChangeLog. Given as "true" or "false".  </td></tr>
 </table>


### PR DESCRIPTION
## What I Did

I replaced the `pre` HTML tags with `code` tags on the [Changelog parameters](https://www.liquibase.org/documentation/changelog_parameters.html) page to have an inline display of the concerned blocks.

## How To Test It

