### PR TITLE
3.8.5 announcement

### DIFF
--- a/_includes/components/announcement.html
+++ b/_includes/components/announcement.html
@@ -1,4 +1,4 @@
 <div style="width: 100%; line-height: 24px; padding: 10px; vertical-align: top; display: block;
     background-color: #416692; text-align: center; color: #ffffff; font-size: 16px; font-weight: bold; margin: 0 auto;">
-    <a style="color: #ffffff; text-decoration: none;" href="https://download.liquibase.org">Liquibase® version 3.8.4 is now available! Get it for free.</a>
+    <a style="color: #ffffff; text-decoration: none;" href="https://download.liquibase.org">Liquibase® version 3.8.5 is now available! Get it for free.</a>
 </div>

--- a/_posts/2020-01-09-liquibase-3.8.5-released.md
+++ b/_posts/2020-01-09-liquibase-3.8.5-released.md
@@ -1,0 +1,41 @@
+---
+layout: default
+subnav: subnav_blog.md
+title: Liquibase 3.8.5 Released, Many Bug Fixes
+---
+Liquibase 3.8.5 is now available here through [Liquibase.org](https://download.liquibase.org/download-community/).
+The [3.8.5 release is also available on GitHub](https://github.com/liquibase/liquibase/releases/). Here’s a closer look at what's included in the latest release.
+
+## Liquibase 3.8.5 Bug Fix Overview
+
+We've fixed a number of issues with this release. 
+
+### Bug Fixes
+For both Liquibase Community and Liquibase Pro users, the following bugs were fixed in version 3.8.5:
+
+- Fixes issue in which Liquibase did not add `DESC` to an `id` column
+- CLI once again accepts `sqlFile`, `delimiter`, `rollbackScript`, and `outputSchemaAs` arguments
+- Fixes Stored Procedure whitespace impacting update calls
+- Fixes `generateChangelog` failure when there are missing NOT NULL constraints
+- Fixes `updateSQL`, which was not including schemaName for package bodies
+- Fixes bug in which Liquibase was not always capturing `create package body` while generating changeLog
+- Liquibase CLI now gives a more useful error message when an invalid character is passed to a command.
+- Fixes an MSSQL issue, which threw an exception when doing diff/diffChangeLog between offline connections (such as when snapshotting json files)
+- Fixes an MSSQL issue, which incorrectly generated `datetime` data type column when using`diff` & `diffChangeLog` Liquibase Maven plugin fails while executing/using "diff" and "generateChangeLog" with PostgreSQL)
+
+## Community Engagement
+We recently shared a [blog about our top findings from our most recent Liquibase Community Survey](https://www.liquibase.org/2020/01/top-10-findings-liquibase-survey.html). Thank you to everyone who participated. 
+
+Want to provide more feedback and input? Ready to learn what we're up to? We're having a virtual Liquibase Community Meetup on January 23 with Nathan (Liquibase Project Founder), Steve (Liquibase Community Manager), and Mario (Liquibase Product Manager). Join us. We're looking forward to meeting with you.<a href="https://register.gotowebinar.com/register/70786962673831938" target="_blank">Register Now.</a>
+
+We are always looking to fix bugs and improve documentation for everyone in the Liquibase community. Here are some ways to contribute:
+- [Contribute code](https://www.liquibase.org/development/contribute.html)
+- [Make doc updates](https://github.com/liquibase/liquibase.github.com/tree/master/documentation)
+
+## More to Explore
+Check out our growing library of videos and [subscribe to our YouTube channel](https://www.youtube.com/channel/UC5qMsRjObu685rTBq0PJX8w?).
+
+Full Liquibase documentation is continually being updated and is available at [http://www.liquibase.org/documentation/index.html](/documentation/index.html). Some of the latest material:
+- [Generating SQL to Update Schemas](http://www.liquibase.org/documentation/generate-sql-update-schemas.html) 
+- [DB2 on Z tutorial](https://www.liquibase.org/documentation/tutorials/db2onz.html)
+

--- a/_posts/2020-01-09-liquibase-3.8.5-released.md
+++ b/_posts/2020-01-09-liquibase-3.8.5-released.md
@@ -19,14 +19,14 @@ For both Liquibase Community and Liquibase Pro users, the following bugs were fi
 - Fixes `generateChangelog` failure when there are missing NOT NULL constraints
 - Fixes `updateSQL`, which was not including schemaName for package bodies
 - Fixes bug in which Liquibase was not always capturing `create package body` while generating changeLog
-- Liquibase CLI now gives a more useful error message when an invalid character is passed to a command.
+- Liquibase CLI now gives a more useful error message when an invalid character is passed to a command
 - Fixes an MSSQL issue, which threw an exception when doing diff/diffChangeLog between offline connections (such as when snapshotting json files)
-- Fixes an MSSQL issue, which incorrectly generated `datetime` data type column when using`diff` & `diffChangeLog` Liquibase Maven plugin fails while executing/using "diff" and "generateChangeLog" with PostgreSQL)
+- Fixes an MSSQL issue, which incorrectly generated `datetime` data type column when using `diff` & `diffChangeLog` Liquibase Maven plugin fails while executing/using "diff" and "generateChangeLog" with PostgreSQL)
 
 ## Community Engagement
 We recently shared a [blog about our top findings from our most recent Liquibase Community Survey](https://www.liquibase.org/2020/01/top-10-findings-liquibase-survey.html). Thank you to everyone who participated. 
 
-Want to provide more feedback and input? Ready to learn what we're up to? We're having a virtual Liquibase Community Meetup on January 23 with Nathan (Liquibase Project Founder), Steve (Liquibase Community Manager), and Mario (Liquibase Product Manager). Join us. We're looking forward to meeting with you.<a href="https://register.gotowebinar.com/register/70786962673831938" target="_blank">Register Now.</a>
+Want to provide more feedback and input? Ready to learn what we're up to? We're having a virtual Liquibase Community Meetup on January 23 with Nathan (Liquibase Project Founder), Steve (Liquibase Community Manager), and Mario (Liquibase Product Manager). Join us. We're looking forward to meeting with you.<a href="https://register.gotowebinar.com/register/70786962673831938" target="_blank"> Register Now.</a>
 
 We are always looking to fix bugs and improve documentation for everyone in the Liquibase community. Here are some ways to contribute:
 - [Contribute code](https://www.liquibase.org/development/contribute.html)
@@ -35,7 +35,7 @@ We are always looking to fix bugs and improve documentation for everyone in the 
 ## More to Explore
 Check out our growing library of videos and [subscribe to our YouTube channel](https://www.youtube.com/channel/UC5qMsRjObu685rTBq0PJX8w?).
 
-Full Liquibase documentation is continually being updated and is available at [http://www.liquibase.org/documentation/index.html](/documentation/index.html). Some of the latest material:
+Full Liquibase documentation is continually being updated and is available at [https://www.liquibase.org/documentation/index.html](/documentation/index.html). Some of the latest material:
 - [Generating SQL to Update Schemas](http://www.liquibase.org/documentation/generate-sql-update-schemas.html) 
 - [DB2 on Z tutorial](https://www.liquibase.org/documentation/tutorials/db2onz.html)
 


### PR DESCRIPTION
## What I Did
Added the 3.8.5 release blog/notes and updated the announcement banner. 
## How To Test It
ensure the blog looks good and is accurate. banner should update to 3.8.5 on the core pages (download and support subdomains are handled separately).