### PR TITLE
changed 14 days to 30 days since we are extending trials

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,7 +70,7 @@ extraStyleSheets:
 			          </ul>
             </div>
             <div class="lb-choose-path__path__button">
-                <a href="https://download.liquibase.org/liquibase-pro-trial-request-form/" class="cta cta--block">Try Free for 14 Days</a>
+                <a href="https://download.liquibase.org/liquibase-pro-trial-request-form/" class="cta cta--block">Try Free for 30 Days</a>
             </div>
         </div>
     </div>

--- a/liquibase-vs-flyway.md
+++ b/liquibase-vs-flyway.md
@@ -88,7 +88,7 @@ extraJavascriptFiles:
     </div>
     <div class="landing-page__cta-block__text">
       <p>
-        Get a free 14-day trial of Liquibase Pro. If you decide you don't want the Pro features, simply keep using the open source version.
+        Get a free 30-day trial of Liquibase Pro. If you decide you don't want the Pro features, simply keep using the open source version.
       </p>
     </div>
     <div class="landing-page__cta-block__cta">


### PR DESCRIPTION
## What I Did
Hot fix to update the trial language from 14 days to 30 days. the trial length has already been updated in the back end. 
## How To Test It
text should now read 30 days instead of 14.