### PR TITLE
Nested elements' details added

### DIFF
--- a/_includes/Arg.md
+++ b/_includes/Arg.md
@@ -1,0 +1,4 @@
+    <tr>
+      <td>value</td>
+      <td>String value of the parameter. Required</td>
+    </tr>

--- a/_includes/IndexColumnConfig.md
+++ b/_includes/IndexColumnConfig.md
@@ -1,0 +1,12 @@
+    <tr>
+      <td>name</td>
+      <td>Name of the column. It can contain the sort direction by appending " ASC" or " DESC" to the name. Required</td>
+    </tr>
+    <tr>
+      <td>computed</td>
+      <td>boolean Set it true if the value in "name" isn't actually a column name but actually a function. <i>Since 3.3.0</i></td>
+    </tr>
+    <tr>
+      <td>descending</td>
+      <td>boolean. Allows to specify that a column should be used in descending order in the index.(i.e. ascending order) <i>Since 3.4</i></td>
+    </tr>

--- a/_includes/LoadDataColumnConfig.md
+++ b/_includes/LoadDataColumnConfig.md
@@ -1,0 +1,18 @@
+    <tr>
+      <td>name</td>
+      <td>Name of the column. <i>Required</i></td>
+    </tr>
+    <tr>
+      <td>type</td>
+      <td>Data type of the column. Its value has to be one of the <a href="../../javadoc/liquibase/change/core/LoadDataChange.LOAD_DATA_TYPE.html" >LOAD_DATA_TYPE</a></td>
+    </tr>
+    <tr>
+      <td>header</td>
+      <td>Name of the column in the CSV file from which the value for the column shall be taken if its different from
+       the column name. Ignored if <i>index</i> is also defined.
+      </td>
+    </tr>
+    <tr>
+      <td>index</td>
+      <td>Index of the column in the CSV file from which the value for the column shall be taken</td>
+    </tr>

--- a/_includes/Param.md
+++ b/_includes/Param.md
@@ -1,0 +1,24 @@
+    <tr>
+      <td>name</td>
+      <td>Name of the parameter</td>
+    </tr>
+    <tr>
+      <td>value</td>
+      <td>Value of the parameter.</td>
+    </tr>
+    <tr>
+      <td>valueNumeric</td>
+      <td>Numeric value of the parameter.</td>
+    </tr>
+    <tr>
+      <td>valueBoolean</td>
+      <td>Boolean value of the parameter.</td>
+    </tr>
+    <tr>
+      <td>valueDate</td>
+      <td>Date and/or Time value to set the column to. The value is specified in one of the following forms: "YYYY-MM-DD", "hh:mm:ss" or "YYYY-MM-DDThh:mm:ss".</td>
+    </tr>
+    <tr>
+      <td>valueComputed</td>
+      <td>A value that is returned from a function or procedure call. This attribute will contain the function to call.</td>
+    </tr>

--- a/documentation/changelog_parameters.md
+++ b/documentation/changelog_parameters.md
@@ -2,32 +2,36 @@
 layout: default
 title: Docs | Changelog parameters 
 ---
-
+<script>
+  $(function() {
+    $( "#changelog-tabs" ).tabs();
+  });
+</script>
 # Change Log Parameters #
 
 **Since Liquibase 1.7**
 
-Liquibase allows dynamic substitution of parameters in a changelog.  The parameters to replace are described using the ${} syntax.
+Liquibase allows dynamic substitution of parameters in a changelog.  The parameters to replace are described using the <b>${parameter-name}</b> syntax.
 
 ## Configuring parameter values ##
 
 Parameter values are looked up in the following order:
 
-  - Passed as a parameter to your Liquibase runner (see [Ant](ant/index.html), [command_line](command_line.html), etc. documentation for how to pass them)
-  - As a JVM system property
-  - In the parameters block (&lt;property&gt; Tag) of the [DatabaseChangeLog](/documentation/databasechangelog.html) file itself
-  - As an environment variable
+  1. Passed as a parameter to your Liquibase runner (see [Ant](ant/index.html), [Maven](maven/index.html) etc. documentation for how to pass them)
+  1. As a JVM system property
+  1. As an environment variable
+  1. [command_line](command_line.html) parameter if used (executed from the command line)
+  1. [properties file](config_properties.html) if used (executed from the command line)
+  1. In the parameters block (<code>property</code> element) of the [DatabaseChangeLog](/documentation/databasechangelog.html) file itself
 
-#### Examples ####
+Once a parameter its value cannot be changed, only the first definition is used, other are skipped. 
 
-{% highlight xml %}
-<createTable tableName="${table.name}">
-     <column name="id" type="int"/>
-     <column name="${column1.name}" type="varchar(${column1.length})"/>
-     <column name="${column2.name}" type="int"/>
-</createTable>
-{% endhighlight %}
-
+<div id='changelog-tabs'>
+<ul>
+    <li><a href="#tab-xml">XML Sample</a></li>
+    <li><a href="#tab-yaml">YAML Sample</a></li>
+</ul>
+<div id='tab-xml'>
 {% highlight xml %}
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
@@ -36,8 +40,9 @@ Parameter values are looked up in the following order:
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-    <property name="clob.type" value="clob" dbms="oracle"/>
+    <property name="clob.type" value="clob" dbms="oracle,postgresql"/>
     <property name="clob.type" value="longtext" dbms="mysql"/>
+    <property name="table.name" value="tableA"/>
 
     <changeSet id="1" author="joe">
          <createTable tableName="${table.name}">
@@ -47,8 +52,42 @@ Parameter values are looked up in the following order:
          </createTable>
     </changeSet>
 </databaseChangeLog>
-
 {% endhighlight %}
+</div>
+<div id='tab-yaml'>
+{% highlight yaml %}
+databaseChangeLog:
+  - property:
+      dbms: oracle,postgresql
+      name: clob.type
+      value: clob
+  - property:
+      dbms: mysql
+      name: clob.type
+      value: longtext
+  - property:
+      name: table.name
+      value: tableA
+  - changeSet:
+      id: 1
+      author: joe
+      changes:
+      - createTable:
+          tableName: ${table.name}
+          columns:
+          - column:
+              name: id
+              type: int
+          - column:
+              name: ${column1.name}
+              type: "${clob.type}
+              defaultValue: a string with an ${undefined.param} param against ${dbNote}
+          - column:
+              name: ${column2.name}
+              type: int
+{% endhighlight %}
+</div></div>
+<p></p>
 
 ### &lt;property&gt; ###
 
@@ -58,19 +97,19 @@ Defines a parameter for the changelog. Given a list of contexts and/or databases
 
 <table>
 <tr><th>Attribute</th><th>Description</th></tr>
-<tr><td>name</td><td>Name of the table's schema <b>required if <i>file</i> is not set</b>  </td></tr>
-<tr><td>value</td><td>Name of the column's table <b>required if <i>file</i> is not set</b>  </td></tr>
+<tr><td>name</td><td>Name of the parameter. <b>Required if <code>file</code> is not set</b></td></tr>
+<tr><td>value</td><td>Value of the of the property. <b>required if <code>file</code> is not set</b>  </td></tr>
 <tr><td>file</td><td>Name of the file the properties shall be loaded from. It will create a property for all properties in the file. 
 The content of the file has to follow the java properties file format</td></tr>
-<tr><td>context</td><td>Contexts given as comma separated list.  </td></tr>
-<tr><td>dbms</td><td>The type of a database which that changeSet is to be used for. When the migration step is running, it checks the database type against this 
+<tr><td>context</td><td>Contexts the property is valid in. Expected as comma separated list.  </td></tr>
+<tr><td>dbms</td><td>The type of a database which that property is to be used. When the migration step is running, it checks the database type against this 
   attribute. Valid database type names are listed on the <a href="../databases.html">supported databases page</a>. It is possible to list multiple databases separated by commas. 
   You can also specify that a changeset is <b>NOT</b> applicable to a particular database type by prefixing with <code>!</code>. The keywords <code>all</code> and <code>none</code> are 
   also available.</td></tr>
-<tr><td>global</td><td>Defines whether the property is global or limited to a databaseChangeLog. Given as "true" or "false".  </td></tr>
+<tr><td>global</td><td>boolean Defines whether the property is global or limited to the actual databaseChangeLog. Given as "true" or "false".  </td></tr>
 </table>
 
-Example:
+Examples:
 
 {% highlight xml %}
     <property name="simpleproperty" value="somevalue"/>

--- a/documentation/changelog_parameters.md
+++ b/documentation/changelog_parameters.md
@@ -58,8 +58,10 @@ Defines a parameter for the changelog. Given a list of contexts and/or databases
 
 <table>
 <tr><th>Attribute</th><th>Description</th></tr>
-<tr><td>name</td><td>Name of the table's schema <b>required</b>  </td></tr>
-<tr><td>value</td><td>Name of the column's table <b>required</b>  </td></tr>
+<tr><td>name</td><td>Name of the table's schema <b>required if <i>file</i> is not set</b>  </td></tr>
+<tr><td>value</td><td>Name of the column's table <b>required if <i>file</i> is not set</b>  </td></tr>
+<tr><td>file</td><td>Name of the file the properties shall be loaded from. It will create a property for all properties in the file. 
+The content of the file has to follow the java properties file format</td></tr>
 <tr><td>context</td><td>Contexts given as comma separated list.  </td></tr>
 <tr><td>dbms</td><td>The type of a database which that changeSet is to be used for. When the migration step is running, it checks the database type against this 
   attribute. Valid database type names are listed on the <a href="../databases.html">supported databases page</a>. It is possible to list multiple databases separated by commas. 

--- a/documentation/changelog_parameters.md
+++ b/documentation/changelog_parameters.md
@@ -17,11 +17,11 @@ Liquibase allows dynamic substitution of parameters in a changelog.  The paramet
 
 Parameter values are looked up in the following order:
 
-  1. Passed as a parameter to your Liquibase runner (see [Ant](ant/index.html), [Maven](maven/index.html) etc. documentation for how to pass them)
+  1. Passed as a parameter to your Liquibase runner (see [Ant](ant/index.html), [Maven](maven/index.html), [Servlet listener](servlet_listener.html)) etc. documentation for how to pass them)
   1. As a JVM system property
   1. As an environment variable
-  1. [command_line](command_line.html) parameter if used (executed from the command line)
-  1. [properties file](config_properties.html) if used (executed from the command line)
+  1. [command_line](command_line.html) parameter if executed from the command line
+  1. [properties file](config_properties.html) if used or executed from the command line
   1. In the parameters block (<code>property</code> element) of the [DatabaseChangeLog](/documentation/databasechangelog.html) file itself
 
 Once a parameter its value cannot be changed, only the first definition is used, other are skipped. 

--- a/documentation/changes/index.md
+++ b/documentation/changes/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Docs | Change executeCommand 
+title: Docs | Refactorings
 ---
 
 # Bundled Liquibase Changes
@@ -8,4 +8,33 @@ title: Docs | Change executeCommand
 Liquibase ships with a large number of refactoring/changes that can be applied to your database as well as the ability to write more through the
 [extension system](../../extensions/index.html).
 
-The bundled changes are listed on the left.
+#### Note
+- Property values are <i>string</i> except noted
+- Boolean parameters are defaulted to <i>false</i> unless otherwise noted
+
+
+| **Entity**| Create / Add | Drop | Change
+|====|===|
+| Table | [createTable](create_table.html) | [dropTable](drop_table.html) | [renameTable](rename_table.html) [setTableRemarks](set_table_remarks.html)
+| Column | [addColumn](add_column.html) |  [dropColumn](drop_column.html) | [renameColumn](rename_column.html) [modityDataType](modify_data_type.html)  [setColumnRemarks](set_column_remarks.html) [addAutoIncrement](add_auto_increment.html)
+| Index | [createIndex](create_index.html) | [dropIndex](drop_index.html) |
+| View | [createView](create_view.html) |  [dropView](drop_view.html) | [renameView](rename_view.html)
+| Procedure | [createProcedure](create_procedure.html) |  [dropProcedure](drop_procedure.html) | 
+| Sequence | [createSequence](create_sequence.html) |  [dropSequence](drop_sequence.html) | [renameSequence](rename_sequence.html) [alterSequence](alter_sequence.html)
+
+| **Constraint**| Add | Drop 
+|====|===|
+| Check | [addCheckConstraint](add_check_constraint.html) | [dropConstraint](drop_check_constraint.html) 
+| Default value | [addDefaultValue](add_default_value.html) | [dropDefaultValue](drop_default_value.html)
+| Foreign key | [addForeignKeyConstraint](add_foreign_key_constraint.html) | [dropForeignKeyConstraint](drop_foreign_key_constraint.html)
+| Not null | [addNotNullConstraint](add_not_null_constraint.html) | [dropNotNullConstraint](drop_not_null_constraint.html) 
+| Primary key | [addPrimaryKey](add_primary_key.html) | [dropPrimaryKey](drop_primary_key.html)
+| Unique key | [addUniqueKeyConstraint](add_unique_constraint.html) | [dropUniqueKeyConstraint](drop_unique_constraint.html) 
+
+| **Data**|  
+|====|===|
+| [insert](insert.html) | [update](update.html) | [delete](delete.html) | [loadData](load_data.html) | [loadUpdateData](load_update_data.html) | [mergeColumns](merge_columns.html) | [addLookupTable](add_lookup_table.html)
+
+| **Misc**|  
+|====|===|
+| [sql](sql.html) | [sqlFile](sql_file.html) | [executeCommand](execute_command.html) | [tagDatabase](tag_database.html) | [stop](stop.html) | [output](output.html) | [customChange](custom_change.html)

--- a/documentation/changes/tagDatabase.html
+++ b/documentation/changes/tagDatabase.html
@@ -1,7 +1,0 @@
-<html>
-<head>
-    <meta http-equiv="refresh" content="0;url=/documentation/changes/tag_database.html">
-    <link rel="canonical" href="/documentation/changes/tag_database.html">
-    <title>Redirecting to /documentation/changes/tag_database.html...</title>
-</head>
-</html>

--- a/documentation/changeset.md
+++ b/documentation/changeset.md
@@ -64,7 +64,8 @@ the names of objects, for example Oracle converts everything to uppercase (unles
 <code>QUOTE_ONLY_RESERVED_WORDS</code> - Quote reserved keywords and invalid column names.</td></tr>
 <tr><td>runOrder</td><td><b>Since 3.5</b></td></tr>
 <tr><td>created</td><td><b>Since 3.5</b></td></tr>
-<tr><td>ignore</td><td><b>Since 3.6</b></td></tr>
+<tr><td>ignore</td><td>Ignore the changesSet from the execution<b>Since 3.6</b></td></tr>
+<tr><td>logicalFilePath</td><td>Use to override the file name and path when creating the unique identifier of change sets. Required when moving or renaming change logs.</td></tr>
 </table>
 
 
@@ -75,7 +76,7 @@ the names of objects, for example Oracle converts everything to uppercase (unles
 <tr><td>preConditions</td><td><a href="preconditions.html">Preconditions</a> that must pass before the change set will be executed.  Useful for doing a data sanity check before doing something unrecoverable such as a dropTable <b>Since 1.7</b> </td></tr>
 <tr><td>&lt;Any Refactoring Tag(s)&gt;</td><td>The database change(s) to run as part of this change set (so called <a href="changes/index.html">refactorings</a>) </td></tr>
 <tr><td>validCheckSum</td><td>Add a checksum that is considered valid for this changeSet, regardless of what is stored in the database. Used 
-primarily when you need to change a changeSet and don't want errors thrown on databases on which it has already run (not a recommended procedure).<b>Since 1.7</b> </td></tr>
+primarily when you need to change a changeSet and don't want errors thrown on databases on which it has already run (not a recommended procedure). Special value "1:any" will match to any checksum and not execute the changeSet on ANY change<b>Since 1.7</b> </td></tr>
 <tr><td>rollback</td><td>SQL statements or refactoring tags that describe how to <a href="rollback.html">rollback</a> the change set </td></tr>
 </table>
 

--- a/documentation/changeset.md
+++ b/documentation/changeset.md
@@ -37,10 +37,10 @@ Each changeSet tag is uniquely identified by the combination of the "id" tag, th
 
 As Liquibase executes the databaseChangeLog, it reads the changeSets in order and, for each one, checks the "databasechangelog" table to see if the combination of id/author/filepath has been run. If it has been run, the changeSet will be skipped unless there is a true "runAlways" tag. After all the changes in the changeSet are run, Liquibase will insert a new row with the id/author/filepath along with an MD5Sum of the changeSet (see below) in the "databasechangelog".
 
+Note
+: <i>filepath</i> is the path how the changeLogFile parameter is defined. Even if the same file is referenced with a different path, that is considered a different file unless the <code>logicalFilePath</code> is defined.
+
 Liquibase attempts to execute each changeSet in a transaction that is committed at the end, or rolled back if there is an error. Some databases will auto-commit statements which interferes with this transaction setup and could lead to an unexpected database state. Therefore, it is usually best to have just one change per changeSet unless there is a group of non-auto-committing changes that you want applied as a transaction such as inserting data.
-
-
-
 
 ## Available Attributes ##
 

--- a/documentation/changeset.md
+++ b/documentation/changeset.md
@@ -56,12 +56,15 @@ Liquibase attempts to execute each changeSet in a transaction that is committed 
 <tr><td><a href="/documentation/contexts.html">context</a></td><td>Controls whether a changeset is executed, depending on runtime settings. Any string can be used for the context name and they are checked case-insensitively. </td></tr>
 <tr><td><a href="/documentation/labels.html">labels</a></td><td>Controls whether a changeset is executed, depending on runtime settings. Any string can be used for the label name and they are checked case-insensitively.</td></tr>
 <tr><td>runInTransaction</td><td>Should the changeSet be ran as a single transaction (if possible)?  Defaults to true.  <b>Warning: be careful with this attribute.  If set to false and an error occurs part way through running a changeSet containing multiple statements, the Liquibase databasechangelog table will be left in an invalid state.  </b><b>Since 1.9</b> </td></tr>
-<tr><td>failOnError</td><td>Should the migration fail if an error occurs while executing the changeSet? </td></tr>
+<tr><td>failOnError</td><td>Should the migration fail if an error occurs while executing the changeSet? <i>Default=true</i></td></tr>
 <tr><td>objectQuotingStrategy</td><td>This controls how object names are quoted in the SQL generated or used in calls to the database. Different databases do different things to
 the names of objects, for example Oracle converts everything to uppercase (unless quoted). There are three possible values. The default value is <code>LEGACY</code>.<br/>
 <code>LEGACY</code> - Same behavior as in Liquibase 2.0<br/>
 <code>QUOTE_ALL_OBJECTS</code> - Every object gets quoted. e.g. person becomes "person".<br/>
 <code>QUOTE_ONLY_RESERVED_WORDS</code> - Quote reserved keywords and invalid column names.</td></tr>
+<tr><td>runOrder</td><td><b>Since 3.5</b></td></tr>
+<tr><td>created</td><td><b>Since 3.5</b></td></tr>
+<tr><td>ignore</td><td><b>Since 3.6</b></td></tr>
 </table>
 
 

--- a/documentation/command_line.md
+++ b/documentation/command_line.md
@@ -98,6 +98,12 @@ the schema in JSON format, and that JSON snapshot can serve as a comparison data
 <tr><td>tag &lt;tag&gt;</td><td>"Tags" the current database state for future rollback.</td></tr>
 <tr><td>tagExists &lt;tag&gt;</td><td>Checks whether the given tag already exists.</td></tr>
 <tr><td>validate</td><td>Checks the changelog for errors.</td></tr>
+<tr><td>calculateCheckSum</td><td></td></tr>
+<tr><td>executeSql</td><td>Parameters:
+      <table><tr><td>sql</td><td>Sql to execute</td></tr>
+            <tr><td>sqlFile</td><td>Sql file to execute</td></tr>
+            <tr><td>delimiter</td><td></td></tr>
+      </table></td></tr>
 </table>
 
 

--- a/documentation/config_properties.md
+++ b/documentation/config_properties.md
@@ -32,6 +32,7 @@ the command line value will override the value in the file.
 | referencePassword | The password for your target database. |
 | liquibaseProLicenseKey | Your Liquibase Pro license key (If you have one). |
 | classpath | The path for your database driver |
+| <code>parameter.</code>[parameter name] | Define global [change log parameter](changelog_parameters.html). E.g. parameter.table.name: tableA
 
 Different commands require different parameter information to work. For more information on parameter requirements, search the Liquibase Command topics in the knowledge base.
 
@@ -48,7 +49,14 @@ referencePassword: password
 liquibaseProLicenseKey: aeioufakekey32aeioufakekey785463214
 classpath: ../path/to/file/ojdbc6-11.2.0.3.0.jar
 {% endhighlight %}
+<p></p>
 
+### Advanced configuration options
+
+| Parameter | Definition |
+| --------- | ---------- |
+| includeCatalogInSpecification | <i>boolean</i> Should Liquibase include the catalog name when determining equality? |
+| convertDataTypes | <i>boolean</i> Should Liquibase convert to/from STANDARD data types. Applies to both <code>snapshot</code> and <code>update</code> commands. Default= true|
 
 ### See Also ###
 * [Using a liquibase.properties file in the command  line](command_line.html#using-a-liquibaseproperties-file)

--- a/documentation/databasechangelog.md
+++ b/documentation/databasechangelog.md
@@ -12,9 +12,14 @@ The root of all Liquibase changes is the databaseChangeLog file.
 <table>
 <tr><th>Attribute</th><th>Description</th></tr>
 <tr><td>logicalFilePath</td><td>Use to override the file name and path when creating the unique identifier of change sets. Required when moving or renaming change logs.</td></tr>
+<tr><td>objectQuotingStrategy</td><td>This controls how object names are quoted in the SQL generated or used in calls to the database. Different databases do different things to
+the names of objects, for example Oracle converts everything to uppercase (unless quoted). There are three possible values. The default value is <code>LEGACY</code>.<br/>
+<code>LEGACY</code> - Same behavior as in Liquibase 2.0<br/>
+<code>QUOTE_ALL_OBJECTS</code> - Every object gets quoted. e.g. person becomes "person".<br/>
+<code>QUOTE_ONLY_RESERVED_WORDS</code> - Quote reserved keywords and invalid column names.</td></tr>
 </table>
 
-## Available Sub-Tags ##
+## Available nested elements ##
 
 <table>
 <tr><th>Tag</th><th>Description</th></tr>

--- a/documentation/include.md
+++ b/documentation/include.md
@@ -39,7 +39,7 @@ ensure that the id/author combinations are unique *within each file*, not across
 <table>
 <tr><th>Attribute</th><th>Description</th></tr>
 <tr><td>file</td><td>Name of the file to import <b>required</b> </td></tr>
-<tr><td>relativeToChangelogFile</td><td>Is the file path relative to the root changelog file rather than to the classpath.  Defaults to "false" <b>since 1.9</b> </td></tr>
+<tr><td>relativeToChangelogFile</td><td>Is the file path relative to the changelog file containing the element rather than to the classpath. Defaults to "false" <b>since 1.9</b> </td></tr>
 <tr><td>context</td><td>Append context (using AND) to all contained changeSets <b>since 3.5</b> </td></tr>
 </table>
 

--- a/documentation/rollback.md
+++ b/documentation/rollback.md
@@ -24,6 +24,8 @@ Other refactorings such as "drop table" and "insert data" have no corresponding 
 `splitStatements` set to `true` and `endDelimiter` set to `;`.</td></tr>
 <tr><td>changeSetId</td><td>Id of changeset to rerun in order to rollback this change.  Example: for rolling back a dropTable change, reference the changeSet that created the table.  </td></tr>
 <tr><td>changeSetAuthor</td><td>Author of changeset to rerun in order to rollback this change  </td></tr>
+<tr><td>changeSetPath</td><td>Normalized name of the file containing the changeset to rerun in order to rollback this
+ changeSet. If not defined, the actual file is used.</td></tr>
 </table>
 
 ## Samples ##


### PR DESCRIPTION
## What I Did
Generator:
- Nested element details added (update|delete/executeCommand/createIndex) / Requires fixes from liquibase-core [PR:992](https://github.com/liquibase/liquibase/pull/992) Similarly to `column` the 2nd level element description is in separate files. To generalize the solution, new annotation might be required similar to `DatabaseChangeProperty`
- Added generic description for some properties (encoding/dbms/relativeToChangelogFile) if not set in the `DatabaseChangeProperty` (A more generic solution might to use separate interfaces for the changes in the core. Or use a simple properties file for the generator)
- More detailed samples: Some shall come from the core + some fixed in the generator

Added Overview table in /documentation/changes/index.md with the available changes
