### PR TITLE
adding commands that are in the source code but not documented

### DIFF
--- a/documentation/command_line.md
+++ b/documentation/command_line.md
@@ -38,6 +38,8 @@ If you run the command line migrator without any arguments, you will get a help 
 <tr><td><a href="/documentation/generate-sql-update-schemas.html">updateSQL</a></td><td>Writes SQL to update database to current version to STDOUT.</td></tr>
 <tr><td>updateCountSQL &lt;value&gt;</td><td>Writes SQL to apply the next &lt;value&gt; change sets to STDOUT.</td></tr>
 <tr><td>updateTestingRollback</td><td>Updates the database, then rolls back changes before updating again.</td></tr>
+<tr><td>updateToTag</td><td>NEEDS DOCS</td></tr>
+<tr><td>updateToTagSQL</td><td>NEEDS DOCS</td></tr>
 </table>
 
 
@@ -54,6 +56,10 @@ If you run the command line migrator without any arguments, you will get a help 
 <tr><td><a href="/documentation/rollbackonechangeset.html">rollbackOneChangeSet</a></td><td>Rolls back a single changeset without needing to roll back other already applied changesets. <span style="color: #fd8c00">Liquibase Pro Feature</span></td></tr>
 <tr><td><a href="/documentation/rollbackonechangeset.html">rollbackOneChangeSetSQL</a></td><td>Writes SQL to roll back a single changest to STDOUT. <span style="color: #fd8c00">Liquibase Pro Feature</span></td></tr>
 <tr><td>futureRollbackSQL</td><td>Writes SQL to roll back the database to the current state after the changes in the changeslog have been applied.</td></tr>
+<tr><td>futureRollbackCountSQL</td><td>NEEDS DOCS</td></tr>
+<tr><td>futureRollbackFromTagSQL</td><td>NEEDS DOCS</td></tr>
+<tr><td>futureRollbackToTagSQL</td><td>NEEDS DOCS</td></tr>
+
 <tr><td>updateTestingRollback</td><td>Updates the database, then rolls back changes before updating again.</td></tr>
 </table>
 
@@ -81,6 +87,9 @@ Can append in any of the supported changelog formats.</td></tr>
 
 <table>
 <tr><th>Command</th><th>Description</th></tr>
+<tr><td>calculateCheckSum</td><td>NEEDS DOCS</td></tr>
+<tr><td>executeSql</td><td>NEEDS DOCS</td></tr>
+
 <tr><td>changelogSync</td><td>Mark all changes as executed in the database.</td></tr>
 <tr><td>changelogSyncSQL</td><td>Writes SQL to mark all changes as executed in the database to STDOUT.</td></tr>
 <tr><td>clearCheckSums</td><td>Removes current checksums from database.  On next update changesets that
@@ -89,12 +98,16 @@ Can append in any of the supported changelog formats.</td></tr>
 <tr><td>dropAll</td><td>Drops all database objects owned by the user. DANGEROUS!</td></tr>
 <tr><td>listLocks</td><td>Lists who currently has locks on the database changelog.</td></tr>
 <tr><td>markNextChangeSetRan</td><td>Mark the next change set as executed in the database.</td></tr>
+<tr><td>markNextChangeSetRanSQL</td><td>Generates the SQL to mark the next change set as executed in the database.</td></tr>
 <tr><td>releaseLocks</td><td>Releases all locks on the database changelog.</td></tr>
 <tr><td>status</td><td>Outputs count (list if --verbose) of unrun change sets.</td></tr>
 <tr><td><a href="/documentation/snapshot.html">snapshot</a></td><td>Gathers the current database schema and displays that information to STDOUT. With options, can save
 the schema in JSON format, and that JSON snapshot can serve as a comparison database.</td></tr>
+<tr><td><a href="/documentation/snapshot.html">snapshotReference</a></td><td>Gathers the current database schema described by the <code>referenceURL</code> and displays that information to STDOUT. With options, can save
+the schema in JSON format, and that JSON snapshot can serve as a comparison database.</td></tr>
 <tr><td>tag &lt;tag&gt;</td><td>"Tags" the current database state for future rollback.</td></tr>
 <tr><td>tagExists &lt;tag&gt;</td><td>Checks whether the given tag already exists.</td></tr>
+<tr><td>unexpectedChangeSets</td><td>NEEDS DOCS</td></tr>
 <tr><td>validate</td><td>Checks the changelog for errors.</td></tr>
 </table>
 


### PR DESCRIPTION
## What I Did
Went through the source code of the Main class, looking at the `private enum COMMANDS` declaration, comparing the commands listed there to those listed in command_line.md. Added missing commands, but still need to add docs for those commands. 

## How To Test It
