### PR TITLE
SDK Reference Removal

### DIFF
--- a/_includes/subnav_development.md
+++ b/_includes/subnav_development.md
@@ -4,7 +4,6 @@
 <li><a href="/development/branches.html"><span>Branches</span></a></li>
 <li><a href="/development/code_org.html"><span>Code Org</span></a></li>
 <li><a href="/development/building.html"><span>Building</span></a></li>
-<li><a href="/documentation/sdk/index.html"><span>SDK</span></a></li>
 <li><a href="/javadoc/index.html"><span>Javadoc</span></a></li>
 <li><a href="/development/jira.html"><span>Using Jira</span></a></li>
 <li><a href="/extensions/index.html"><span>Extension Portal</span></a></li>

--- a/_includes/subnav_documentation.md
+++ b/_includes/subnav_documentation.md
@@ -4,5 +4,4 @@
 <li><a href="/documentation/core-concepts/index.html"><span>Core Concepts</span></a></li>
 <li><a href="/documentation/tutorials/index.html"><span>Tutorials</span></a></li>
 <li><a href="/documentation/changes/index.html"><span>Refactoring Commands</span></a></li>
-<li><a href="/documentation/sdk/index.html"><span>Liquibase SDK</span></a></li>
 

--- a/documentation/sdk/index.md
+++ b/documentation/sdk/index.md
@@ -5,16 +5,4 @@ title: Docs | SDK Home
 
 # Liquibase SDK
 
-### Purpose and Installation
-
-The purpose of the Liquibase SDK is facilitate development and testing of the Liquibase codebase and Liquibase extensions.
-The Liquibase SDK ships with the standard command line Liquibase installation which can be downloaded from [the Liquibase download page](http://download.liquibase.org).
-
-After unzipping liquibase-bin.zip or liquibase-bin.tar.gz you will find an "sdk" sub directory which contains everything related to the SDK.
-
-__Liquibase SDK is available in Liquibase 3.2.0+__
-
-### SDK Components
-
-* [__Javadoc__](/javadoc) The Liquibase core library API documentation is included in the LIQUIBASE_HOME/sdk/javadoc directory for easy offline reference.
-* [__Workspace__](workspace.html) To make testing easier, a pre-configured "workspace" directory is included with sample changelog files.
+At this time, the Liquibase SDK has been deprecated. Stay tuned for new feature announcements on our [Liquibase blog](http://www.liquibase.org/blog/).

--- a/documentation/sdk/workspace.md
+++ b/documentation/sdk/workspace.md
@@ -5,46 +5,4 @@ title: Docs | Workspace
 
 # Liquibase SDK Workspace
 
-The Liquibase SDK ships with a LIQUIBASE_HOME/sdk/workspace directory that is pre-configured as an easy starting point for testing Liquibase and Liquibase extensions.
-
-Normal usage of the workspace directory is to change to the workspace directory, then run `..\..\liquibase ARGS` and `..\liquibase-sdk ARGS` commands.
-
-__Liquibase SDK is available in Liquibase 3.2.0+__
-
-## Standard Workspace Contents
-
-### liquibase.properties
-
-The workspace directory ships with liquibase.h2.properties, liquibase.hsql.properties and liquibase.derby.properties files in the workspace directory which can be used for testing
-embedded databases. All three are configured to use database files in LIQUIBASE_HOME/tmp/DB_NAME.
-
-
-### changelog
-
-LIQUIBASE_HOME/sdk/changelog contains a starting `com/example/changelog.xml` file that can be used as a starting point for testing. 
-
-
-The com/example/changelog.xml uses a variety of features including:
-
-* multiple authors
-* runAlways
-* dbms filtering
-* include
-* includeAll
-* relativeToChangelogFile
-* formatted SQL changelog format
-* YAML changelog format
-* rollback logic
-
-The created database structure includes:
-
-* A debug_info table for easy message logging
-* An employee table with an address table that references it
-* A simple shopping cart structure with item, account and cart_item tables
-* A simple newspaper structure with article and page tables
-
-## Tips
-
-* Zip or tar the the workspace directory for future reference and recovery
-* Add the workspace directory to your IDE project for easy access
-* Use the standard changelog structure as a starting point for reproducing and submitting Liquibase bugs
+At this time, the Liquibase SDK has been deprecated. Stay tuned for new feature announcements on our [Liquibase blog](http://www.liquibase.org/blog/).


### PR DESCRIPTION
## What I Did Removed all links to SDK and changed pages to advise of deprecation.

FYI - as a company it is bad practice to say something might come back in the future when we don't know. So my message states to check out new feature announcements in the blog.

## How To Test It: Review
